### PR TITLE
fix: numpy searcher docs traversal

### DIFF
--- a/jinahub/indexers/searcher/NumpySearcher/__init__.py
+++ b/jinahub/indexers/searcher/NumpySearcher/__init__.py
@@ -72,7 +72,7 @@ class NumpySearcher(Executor):
         else:
             self.logger.error(f'Metric {self.metric} not supported.')
         positions, dist = self._get_sorted_top_k(dists, top_k)
-        for _q, _positions, _dists in zip(docs, positions, dist):
+        for _q, _positions, _dists in zip(docs.traverse_flat(traversal_paths), positions, dist):
             for position, dist in zip(_positions, _dists):
                 d = Document(id=self._ids[position], embedding=self._vecs[position])
                 if self.is_distance:

--- a/jinahub/indexers/searcher/NumpySearcher/__init__.py
+++ b/jinahub/indexers/searcher/NumpySearcher/__init__.py
@@ -57,7 +57,7 @@ class NumpySearcher(Executor):
             self.logger.info('No documents to search for')
             return
 
-        if not doc_embeddings:
+        if len(doc_embeddings) == 0 or not doc_embeddings:
             self.logger.info('None of the docs have any embeddings')
             return
 

--- a/jinahub/indexers/searcher/NumpySearcher/__init__.py
+++ b/jinahub/indexers/searcher/NumpySearcher/__init__.py
@@ -56,11 +56,15 @@ class NumpySearcher(Executor):
         if not docs:
             self.logger.info('No documents to search for')
             return
-
+        print('******before')
+        print(doc_embeddings)
+        print('******')
         if len(doc_embeddings) == 0 or not doc_embeddings:
             self.logger.info('None of the docs have any embeddings')
             return
-
+        print('******after')
+        print(doc_embeddings)
+        print('******')
         doc_embeddings = np.stack(doc_embeddings)
 
         q_emb = _ext_A(_norm(doc_embeddings))

--- a/jinahub/indexers/searcher/NumpySearcher/__init__.py
+++ b/jinahub/indexers/searcher/NumpySearcher/__init__.py
@@ -56,15 +56,9 @@ class NumpySearcher(Executor):
         if not docs:
             self.logger.info('No documents to search for')
             return
-        print('******before')
-        print(doc_embeddings)
-        print('******')
-        if len(doc_embeddings) == 0 or not doc_embeddings:
+        if not doc_embeddings or doc_embeddings[0] is None:
             self.logger.info('None of the docs have any embeddings')
             return
-        print('******after')
-        print(doc_embeddings)
-        print('******')
         doc_embeddings = np.stack(doc_embeddings)
 
         q_emb = _ext_A(_norm(doc_embeddings))

--- a/jinahub/indexers/searcher/NumpySearcher/tests/test_query.py
+++ b/jinahub/indexers/searcher/NumpySearcher/tests/test_query.py
@@ -83,7 +83,7 @@ def test_empty_documents(tmpdir):
         'replica_id': 0,
     }
     indexer = NumpySearcher(dump_path='tests/dump1', runtime_args=runtime)
-    docs = DocumentArray([Document(id=0)])
+    docs = DocumentArray([Document()])
     indexer.search(docs, {'top_k': TOP_K})
     assert len(docs) == 1
     assert len(docs[0].matches) == 0

--- a/jinahub/indexers/searcher/NumpySearcher/tests/test_query.py
+++ b/jinahub/indexers/searcher/NumpySearcher/tests/test_query.py
@@ -10,28 +10,37 @@ TOP_K = 5
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_query_vector(tmpdir):
+@pytest.fixture()
+def query_docs():
+    chunks = DocumentArray([Document(embedding=np.random.random(7))])
+    root_doc = Document(embedding=np.random.random(7))
+    root_doc.chunks.extend(chunks)
+    docs = DocumentArray()
+    docs.append(root_doc)
+    return docs
+
+
+@pytest.mark.parametrize('default_traversal_paths', [['r'], ['c']])
+def test_query_vector(tmpdir, query_docs, default_traversal_paths):
     runtime = {
         'workspace': str(tmpdir),
         'name': 'searcher',
         'pea_id': 0,
         'replica_id': 0,
     }
-
     dump_path = os.path.join(cur_dir, 'dump1')
-    indexer = NumpySearcher(dump_path=dump_path, runtime_args=runtime)
-    docs = DocumentArray([Document(embedding=np.random.random(7))])
-    TOP_K = 5
-    indexer.search(docs, {'top_k': TOP_K})
-    assert len(docs) == 1
-    assert len(docs[0].matches) == TOP_K
-    assert len(docs[0].matches[0].embedding) == 7
+    indexer = NumpySearcher(dump_path=dump_path, default_traversal_paths=default_traversal_paths, runtime_args=runtime)
+    indexer.search(query_docs, {'top_k': TOP_K})
+    assert len(query_docs) == 1
+    doc_traversal = query_docs.traverse_flat(default_traversal_paths)
+    assert len(doc_traversal[0].matches) == TOP_K
+    assert len(doc_traversal[0].matches[0].embedding) == 7
 
 
 @pytest.mark.parametrize(['metric', 'is_distance'],
                          [('cosine', True), ('euclidean', True),
                           ('cosine', False), ('euclidean', False)])
-def test_metric(tmpdir, metric, is_distance):
+def test_metric(tmpdir, query_docs, metric, is_distance):
     runtime = {
         'workspace': str(tmpdir),
         'name': 'searcher',
@@ -42,18 +51,18 @@ def test_metric(tmpdir, metric, is_distance):
     dump_path = os.path.join(cur_dir, 'dump1')
     indexer = NumpySearcher(dump_path=dump_path, default_top_k=TOP_K, runtime_args=runtime, metric=metric,
                             is_distance=is_distance)
-    docs = DocumentArray([Document(embedding=np.random.random(7))])
-    indexer.search(docs, {})
-    assert len(docs[0].matches) == TOP_K
 
-    for i in range(len(docs[0].matches) - 1):
+    indexer.search(query_docs, {})
+    assert len(query_docs[0].matches) == TOP_K
+
+    for i in range(len(query_docs[0].matches) - 1):
         if not is_distance:
-            assert docs[0].matches[i].scores[metric].value >= docs[0].matches[i + 1].scores[metric].value
+            assert query_docs[0].matches[i].scores[metric].value >= query_docs[0].matches[i + 1].scores[metric].value
         else:
-            assert docs[0].matches[i].scores[metric].value <= docs[0].matches[i + 1].scores[metric].value
+            assert query_docs[0].matches[i].scores[metric].value <= query_docs[0].matches[i + 1].scores[metric].value
 
 
-def test_empty_shard(tmpdir):
+def test_empty_shard(tmpdir, query_docs):
     runtime = {
         'workspace': str(tmpdir),
         'name': 'searcher',
@@ -61,11 +70,9 @@ def test_empty_shard(tmpdir):
         'replica_id': 0,
     }
     indexer = NumpySearcher(dump_path='tests/dump_empty', runtime_args=runtime)
-    docs = DocumentArray([Document(embedding=np.random.random(7))])
-    TOP_K = 5
-    indexer.search(docs, {'top_k': TOP_K})
-    assert len(docs) == 1
-    assert len(docs[0].matches) == 0
+    indexer.search(query_docs, {'top_k': TOP_K})
+    assert len(query_docs) == 1
+    assert len(query_docs[0].matches) == 0
 
 
 def test_empty_documents(tmpdir):
@@ -77,7 +84,6 @@ def test_empty_documents(tmpdir):
     }
     indexer = NumpySearcher(dump_path='tests/dump1', runtime_args=runtime)
     docs = DocumentArray([Document(id=0)])
-    TOP_K = 5
     indexer.search(docs, {'top_k': TOP_K})
     assert len(docs) == 1
     assert len(docs[0].matches) == 0


### PR DESCRIPTION
the NumpySearcher used to add matches to the root level, but it should add them into the corresponding traversal level, then will be helpful for ranker to rerank