### PR TITLE
fix(lmdb): load from dumped data

### DIFF
--- a/jinahub/indexers/storage/LMDBStorage/lmdb_storage.py
+++ b/jinahub/indexers/storage/LMDBStorage/lmdb_storage.py
@@ -85,7 +85,7 @@ class LMDBStorage(Executor):
                 serialized_doc = Document(meta)
                 serialized_doc.id = id
                 da.append(serialized_doc)
-            self.index(da, parameters={})
+            self.index(da, parameters={'traversal_paths': ['r']})
         self.default_return_embeddings = default_return_embeddings
 
     def _handler(self):


### PR DESCRIPTION
In some project, the `default_traversal_paths` is set as `["cm"]`. That will broke the loading function.