### PR TITLE
feat: simple indexer does not crash on none

### DIFF
--- a/jinahub/indexers/SimpleIndexer/Dockerfile
+++ b/jinahub/indexers/SimpleIndexer/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:2.0.7
+FROM jinaai/jina:2.0.16-perf
 # install the third-party requirements
 RUN apt-get update && apt-get install -y python3.7 python3.7-dev python3-pip git
 

--- a/jinahub/indexers/SimpleIndexer/simple_indexer.py
+++ b/jinahub/indexers/SimpleIndexer/simple_indexer.py
@@ -57,6 +57,7 @@ class SimpleIndexer(Executor):
         :param docs: the docs to add
         :param parameters: the parameters dictionary
         """
+        if not docs: return
         traversal_path = parameters.get('traversal_paths', self.default_traversal_paths)
         flat_docs = docs.traverse_flat(traversal_path)
         self._docs.extend(flat_docs)
@@ -68,6 +69,7 @@ class SimpleIndexer(Executor):
 
         :param docs: the Documents to search with
         :param parameters: the parameters for the search"""
+        if not docs: return
         traversal_path = parameters.get('traversal_paths', self.default_traversal_paths)
         top_k = parameters.get('top_k', self.default_top_k)
         flat_docs = docs.traverse_flat(traversal_path)

--- a/jinahub/indexers/SimpleIndexer/simple_indexer.py
+++ b/jinahub/indexers/SimpleIndexer/simple_indexer.py
@@ -107,6 +107,7 @@ class SimpleIndexer(Executor):
 
         :param docs: DocumentArray to search with
         """
+        if not docs: return
         for doc in docs:
             doc.embedding = self._docs[doc.id].embedding
 


### PR DESCRIPTION
Simple Indexer crashed on docs = None in the cross modal example. This PR fixes that.