### PR TITLE
fix: ensure that top_k is integer

### DIFF
--- a/jinahub/indexers/SimpleIndexer/simple_indexer.py
+++ b/jinahub/indexers/SimpleIndexer/simple_indexer.py
@@ -90,7 +90,7 @@ class SimpleIndexer(Executor):
         flat_docs = docs.traverse_flat(traversal_paths)
         if not flat_docs:
             return
-        top_k = parameters.get('top_k', self.default_top_k)
+        top_k = int(parameters.get('top_k', self.default_top_k))
         flat_docs.match(
             self._docs,
             metric=lambda q_emb, d_emb, _: self.distance(


### PR DESCRIPTION
I encountered an error in the examples with top_k being not integer. 
The parameter transferred by the frontend of the example is integer so womewhere on the way it seems to be converted to float. This commit fixes this by enforcing top_k to be integer.