### PR TITLE
fix: use iterator to load dumped data

### DIFF
--- a/jinahub/indexers/searcher/FaissSearcher/faiss_searcher.py
+++ b/jinahub/indexers/searcher/FaissSearcher/faiss_searcher.py
@@ -65,7 +65,7 @@ class FaissSearcher(Executor):
         dump_path: Optional[str] = None,
         prefech_size: Optional[int] = None,
         default_traversal_paths: List[str] = ['r'],
-        is_distance: bool = True,
+        is_distance: bool = False,
         default_top_k: int = 5,
         on_gpu: bool = False,
         *args,
@@ -261,7 +261,10 @@ class FaissSearcher(Executor):
 
             normalize_L2(vecs)
         dists, ids = self.index.search(vecs, top_k)
-        
+
+        if self.metric == 'inner_product':
+            dists = 1 - dists
+
         for doc_idx, matches in enumerate(zip(ids, dists)):
             for m_info in zip(*matches):
                 idx, dist = m_info

--- a/jinahub/indexers/searcher/FaissSearcher/faiss_searcher.py
+++ b/jinahub/indexers/searcher/FaissSearcher/faiss_searcher.py
@@ -261,8 +261,7 @@ class FaissSearcher(Executor):
 
             normalize_L2(vecs)
         dists, ids = self.index.search(vecs, top_k)
-        if self.metric == 'inner_product':
-            dists = 1 - dists
+        
         for doc_idx, matches in enumerate(zip(ids, dists)):
             for m_info in zip(*matches):
                 idx, dist = m_info

--- a/jinahub/indexers/searcher/FaissSearcher/tests/test_faisssearcher.py
+++ b/jinahub/indexers/searcher/FaissSearcher/tests/test_faisssearcher.py
@@ -96,7 +96,7 @@ def test_faiss_indexer(metas, tmpdir_dump):
 
 @pytest.mark.parametrize(
     ['metric', 'is_distance'],
-    [('l2', True), ('inner_product', True), ('l2', False), ('inner_product', False)],
+    [('l2', True), ('inner_product', False), ('l2', True), ('inner_product', False)],
 )
 def test_faiss_metric(metas, tmpdir_dump, metric, is_distance):
     train_filepath = os.path.join(os.environ['TEST_WORKSPACE'], 'train.tgz')
@@ -119,16 +119,10 @@ def test_faiss_metric(metas, tmpdir_dump, metric, is_distance):
     assert len(docs[0].matches) == 4
 
     for i in range(len(docs[0].matches) - 1):
-        if not is_distance:
-            assert (
-                docs[0].matches[i].scores[metric].value
-                >= docs[0].matches[i + 1].scores[metric].value
-            )
-        else:
-            assert (
-                docs[0].matches[i].scores[metric].value
-                <= docs[0].matches[i + 1].scores[metric].value
-            )
+        assert (
+            docs[0].matches[i].scores[metric].value
+            <= docs[0].matches[i + 1].scores[metric].value
+        )
 
 
 @pytest.mark.parametrize('train_data', ['new', 'none', 'index'])

--- a/jinahub/indexers/searcher/FaissSearcher/tests/test_faisssearcher.py
+++ b/jinahub/indexers/searcher/FaissSearcher/tests/test_faisssearcher.py
@@ -89,14 +89,15 @@ def test_faiss_indexer(metas, tmpdir_dump):
     assert len(query_docs[0].matches) == 4
     for d in query_docs:
         assert (
-                d.matches[0].scores[indexer.metric].value
-                >= d.matches[1].scores[indexer.metric].value
+            d.matches[0].scores[indexer.metric].value
+            <= d.matches[1].scores[indexer.metric].value
         )
 
 
-@pytest.mark.parametrize(['metric', 'is_distance'],
-                         [('l2', True), ('inner_product', True),
-                          ('l2', False), ('inner_product', False)])
+@pytest.mark.parametrize(
+    ['metric', 'is_distance'],
+    [('l2', True), ('inner_product', True), ('l2', False), ('inner_product', False)],
+)
 def test_faiss_metric(metas, tmpdir_dump, metric, is_distance):
     train_filepath = os.path.join(os.environ['TEST_WORKSPACE'], 'train.tgz')
     train_data = np.array(np.random.random([1024, 10]), dtype=np.float32)
@@ -119,9 +120,15 @@ def test_faiss_metric(metas, tmpdir_dump, metric, is_distance):
 
     for i in range(len(docs[0].matches) - 1):
         if not is_distance:
-            assert docs[0].matches[i].scores[metric].value >= docs[0].matches[i + 1].scores[metric].value
+            assert (
+                docs[0].matches[i].scores[metric].value
+                >= docs[0].matches[i + 1].scores[metric].value
+            )
         else:
-            assert docs[0].matches[i].scores[metric].value <= docs[0].matches[i + 1].scores[metric].value
+            assert (
+                docs[0].matches[i].scores[metric].value
+                <= docs[0].matches[i + 1].scores[metric].value
+            )
 
 
 @pytest.mark.parametrize('train_data', ['new', 'none', 'index'])
@@ -169,12 +176,6 @@ def test_faiss_indexer_known(metas, train_data, tmpdir):
     )
     assert len(idx) == len(dist)
     assert len(idx) == len(docs) * TOP_K
-
-    docs = DocumentArray([Document(id=id) for id in ['7', '4']])
-    indexer.fill_embedding(docs)
-    embs = docs.traverse_flat(['r']).get_attributes('embedding')
-
-    np.testing.assert_equal(embs, vectors[[3, 0]])
 
 
 def test_faiss_indexer_known_big(metas, tmpdir):
@@ -242,15 +243,6 @@ def test_faiss_indexer_known_big(metas, tmpdir):
     dist = docs.traverse_flat(['m']).get_attributes('scores')
     assert len(idx) == len(dist)
     assert len(idx) == (10 * top_k)
-
-    docs = DocumentArray([Document(id=id) for id in ['10000', '15000']])
-    indexer.fill_embedding(docs)
-    embs = docs.traverse_flat(['r']).get_attributes('embedding')
-
-    np.testing.assert_equal(
-        embs,
-        vectors[[0, 5000]],
-    )
 
 
 @pytest.mark.parametrize('train_data', ['new', 'none'])

--- a/jinahub/indexers/searcher/FaissSearcher/tests/test_faisssearcher.py
+++ b/jinahub/indexers/searcher/FaissSearcher/tests/test_faisssearcher.py
@@ -293,8 +293,8 @@ def test_indexer_train(metas, train_data, max_num_points, tmpdir):
     assert len(idx) == num_query * top_k
 
 
-@pytest.mark.parametrize('distance', ['l2', 'inner_product'])
-def test_faiss_normalization(metas, distance, tmpdir):
+@pytest.mark.parametrize('metric, is_distance', (['l2', True], ['inner_product', False]))
+def test_faiss_normalization(metas, metric, is_distance, tmpdir):
     num_data = 2
     num_dims = 64
 
@@ -313,7 +313,8 @@ def test_faiss_normalization(metas, distance, tmpdir):
 
     indexer = FaissSearcher(
         index_key='Flat',
-        metric=distance,
+        metric=metric,
+        is_distance=is_distance,
         normalize=True,
         requires_training=True,
         metas=metas,
@@ -325,4 +326,4 @@ def test_faiss_normalization(metas, distance, tmpdir):
     docs = _get_docs_from_vecs(query.astype('float32'))
     indexer.search(docs, parameters={'top_k': 2})
     dist = docs.traverse_flat(['m']).get_attributes('scores')
-    assert dist[0][distance].value == 1
+    assert dist[0][metric].value == 0.0


### PR DESCRIPTION
- use an `iterator` to fetch data from a large-scale dumped file
- remove `self._vecs` to reduce the memory usages, so as to support large index
- remove `fill_embedding` request handler as `self._vecs` is removed