### PR TITLE
docs: add warning to simple indexer

### DIFF
--- a/jinahub/indexers/SimpleIndexer/README.md
+++ b/jinahub/indexers/SimpleIndexer/README.md
@@ -23,9 +23,11 @@
 
 ### 🚚 Via JinaHub
 
-#### using docker images
+#### using docker images (not recommended)
 
-Use the prebuilt images from JinaHub in your Python code: 
+> This method is currently not recommended for the SimpleIndexer because there is a bug corrupting the indexed data. We recommend using this executor from source code instead! See 'using source code' section below)
+
+Use the prebuilt images from JinaHub in your Python code:
 
 ```python
 from jina import Flow


### PR DESCRIPTION
The simple indexer is currently experiencing a bug when running it with docker `jinahub+docker://SimpleIndexer`.
After closing the docker container, it sometimes happens that the stored memmap which is mounted into the container is corrupted. After data, the entire index is broken and the user needs to index from scratch.

The error does not happen when using `jinahub://SimpleIndexer` which is why I quickly changed the README to make the user aware of this problem.