### PR TITLE
feat: added missing endpoints

### DIFF
--- a/jinahub/indexers/searcher/compound/FaissPostgresSearcher/faisspsql.py
+++ b/jinahub/indexers/searcher/compound/FaissPostgresSearcher/faisspsql.py
@@ -11,7 +11,9 @@ from jina_commons import get_logger
 try:
     from jinahub.indexers.searcher.FaissSearcher import FaissSearcher
 except:
-    from jina_executors.indexers.searcher.FaissSearcher.faiss_searcher import FaissSearcher
+    from jina_executors.indexers.searcher.FaissSearcher.faiss_searcher import (
+        FaissSearcher,
+    )
 
 try:
     from jinahub.indexers.storage.PostgreSQLStorage import (
@@ -33,16 +35,16 @@ class FaissPostgresSearcher(Executor):
     ):
         super().__init__(**kwargs)
         # when constructed from rolling update the dump_path is passed via a runtime_arg
-        dump_path = dump_path or kwargs.get('runtime_args').get('dump_path')
+        self._init_kwargs = kwargs
+        dump_path = dump_path or self._init_kwargs.get('runtime_args').get('dump_path')
         self.logger = get_logger(self)
-        self._kv_indexer = None
-        self._vec_indexer = None
+        self._kv_indexer = PostgreSQLStorage(**self._init_kwargs)
         if dump_path:
-            self._vec_indexer = FaissSearcher(dump_path=dump_path, **kwargs)
-            self._kv_indexer = PostgreSQLStorage(**kwargs)
+            self._vec_indexer = FaissSearcher(dump_path=dump_path, **self._init_kwargs)
         else:
+            self._vec_indexer = None
             self.logger.warning(
-                f'No dump path provided for {self}. Use .rolling_update() to re-initialize...'
+                f'No dump path provided for {self}. Use /reload to re-initialize...'
             )
 
     @requests(on='/search')
@@ -55,4 +57,35 @@ class FaissPostgresSearcher(Executor):
             ]
             self._kv_indexer.search(docs, kv_parameters)
         else:
+            self.logger.warning(
+                'Not all sub-indexers initialized. Use /reload to re-initialize...'
+            )
+
+    @requests(on='/dump')
+    def dump(self, parameters: Dict, **kwargs):
+        """Dump the index
+
+        :param parameters: a dictionary containing the parameters for the dump
+        """
+        self._kv_indexer.dump(parameters, **kwargs)
+
+    @requests(on='/reload')
+    def reload(self, parameters: Dict, **kwargs):
+        dump_path = parameters.get('dump_path', None)
+        if dump_path is None:
+            self.logger.error(f'No "dump_path" provided for {self}')
             return
+
+        self._vec_indexer = FaissSearcher(dump_path=dump_path, **self._init_kwargs)
+
+    @requests(on='/index')
+    def index(self, **kwargs):
+        self._kv_indexer.add(**kwargs)
+
+    @requests(on='/update')
+    def update(self, **kwargs):
+        self._kv_indexer.update(**kwargs)
+
+    @requests(on='/delete')
+    def delete(self, **kwargs):
+        self._kv_indexer.delete(**kwargs)


### PR DESCRIPTION
This PR allows easy drop-in replacement for the SimpleIndexer. Changes needed in the wikipedia-example:

```
# flows/flow.yml

-    uses: 'jinahub://SimpleIndexer'                   # We use the SimpleIndexer for this purpose
+    uses: 'jinahub+docker://FaissPostgresSearcher
```

```
# app.py Add roughly the following code

def all_in_one(num_docs, top_k):
    flow = Flow().load_config('flows/flow.yml')
    data_path = os.path.join(
        os.path.dirname(__file__), os.environ.get('JINA_DATA_FILE', None)
    )
    with flow:
        flow.post(
            on='/index', inputs=input_generator(num_docs, data_path), show_progress=True
        )
        flow.post(on='/dump', parameters={'dump_path': 'my_dump.dump', 'shards': 1})
        flow.post(on='/reload', parameters={'dump_path': 'my_dump.dump'})
        while True:
            text = input('Please type a sentence: ')
            doc = Document(content=text)
            result = flow.post(
                on='/search',
                inputs=DocumentArray([doc]),
                parameters={'top_k': top_k},
                line_format='text',
                return_results=True,
            )
            print_topk(result[0], text)

```

The `all_in_one` is a combination of `/index` and `/query` combined into one Flow. The additional lines are actually only `flow.post(on='/dump'...)` and `flow.post(on='/reload'...)`. They will be combined into one in the future.