### PR TITLE
ci(cd): avoid updating one Executor in parallel(latest and gpu) tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
   gpu-folders:
+    needs: [push-executors]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
I found that multiple update operations on the same Executor in parallel will cause some problems.

Let's first do it serially. And I'll optimize the parallel things (I need to redesign some data structure, so may take several days). Is that ok to you? 

@jacobowitz @tadejsv 