### PR TITLE
fix: use latest indexer link

### DIFF
--- a/jinahub/indexers/README.md
+++ b/jinahub/indexers/README.md
@@ -4,4 +4,4 @@ This repository contains a selection of Executors for Jina 2.0.
 They are to be used for storing or retrieving your data.
 They are referred to as Indexers.
 
-You can read more about their usage [here](https://docs.jina.ai/fundamentals/executor/indexers/).
+You can read more about their usage [here](https://docs.jina.ai/advanced/experimental/indexers/).


### PR DESCRIPTION
the old [link](https://docs.jina.ai/fundamentals/executor/indexers/) gives 404 not found error