### PR TITLE
fix: use python 3.8 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,11 @@ jobs:
       - name: Python requirements
         run: pip install -r requirements.txt -r tests/requirements.txt
       - name: Create Dockerfile, if needed
-        run: |
-          if [[ ! -f "Dockerfile" ]]; then
-            docker run --entrypoint="normalizer" -v "$(pwd):/workspace" jinahub/hubble-normalizer:latest . --jina-version=2; sudo chown -R $(id -u ${USER}):$(id -g ${USER}) . ; fi
+          run: |
+            if [[ ! -f "Dockerfile" ]]; then
+              docker run --entrypoint="normalizer" -v "$(pwd):/workspace" \
+              jinahub/hubble-normalizer:v0.1.0 . --jina-version=2
+              sudo chown -R $(id -u ${USER}):$(id -g ${USER}) . ; fi
       - name: Run unit tests
         run: pytest -s -v -m "not gpu"
       # - name: Print image size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.7"
       - name: Pre-test script
         run: |
           if [[ -f "tests/pre_test.sh" ]]; then
@@ -78,7 +78,7 @@ jobs:
       - name: Create Dockerfile, if needed
         run: |
           if [[ ! -f "Dockerfile" ]]; then
-            normalizer . --jina-version=2; fi
+            docker run --entrypoint="normalizer" -v "$(pwd):/workspace" jinahub/hubble-normalizer:latest . --jina-version=2; fi
       - name: Run unit tests
         run: pytest -s -v -m "not gpu"
       # - name: Print image size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,12 @@ jobs:
               | select(startswith("2."))' \
             | sort -V | tail -1)
           pip install git+https://github.com/jina-ai/jina.git@v${JINA_VERSION}
-      - name: Install image normalizer
-        run: pip install git+https://github.com/jina-ai/executor-normalizer
       - name: Python requirements
         run: pip install -r requirements.txt -r tests/requirements.txt
       - name: Create Dockerfile, if needed
         run: |
           if [[ ! -f "Dockerfile" ]]; then
-            docker run --entrypoint="normalizer" -v "$(pwd):/workspace" jinahub/hubble-normalizer:latest . --jina-version=2; fi
+            docker run --entrypoint="normalizer" -v "$(pwd):/workspace" jinahub/hubble-normalizer:latest . --jina-version=2; sudo chown -R $(id -u ${USER}):$(id -g ${USER}) . ; fi
       - name: Run unit tests
         run: pytest -s -v -m "not gpu"
       # - name: Print image size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Pre-test script
         run: |
           if [[ -f "tests/pre_test.sh" ]]; then


### PR DESCRIPTION
Executor normalizer needs python 3.8 (needs recent AST library)
closes https://github.com/jina-ai/executors/pull/178