### PR TITLE
feat(gpu): split ranker into cpu and gpu

### DIFF
--- a/jinahub/rankers/DPRReaderRanker/Dockerfile.gpu
+++ b/jinahub/rankers/DPRReaderRanker/Dockerfile.gpu
@@ -1,0 +1,10 @@
+FROM jinaai/jina:2-py37-perf
+
+RUN apt update && apt install -y git
+COPY gpu_requirements.txt gpu_requirements.txt
+RUN pip install --no-cache-dir -r gpu_requirements.txt
+
+COPY . /workdir/
+WORKDIR /workdir
+
+ENTRYPOINT ["jina", "executor", "--uses", "config.yml"]

--- a/jinahub/rankers/DPRReaderRanker/dpr_reader.py
+++ b/jinahub/rankers/DPRReaderRanker/dpr_reader.py
@@ -171,7 +171,7 @@ class DPRReaderRanker(Executor):
             texts=contexts,
             padding='longest',
             return_tensors='pt',
-        )
+        ).to(self.device)
         outputs = self.model(**encoded_inputs)
 
         # For each context, extract num_spans_per_match best spans
@@ -185,8 +185,10 @@ class DPRReaderRanker(Executor):
         new_matches = []
         for span in best_spans:
             new_match = Document(text=span.text)
-            new_match.scores['relevance_score'] = _logistic_fn(span.relevance_score)
-            new_match.scores['span_score'] = _logistic_fn(span.span_score)
+            new_match.scores['relevance_score'] = _logistic_fn(
+                span.relevance_score.cpu()
+            )
+            new_match.scores['span_score'] = _logistic_fn(span.span_score.cpu())
             if titles:
                 new_match.tags['title'] = titles[span.doc_id]
             new_matches.append(new_match)

--- a/jinahub/rankers/DPRReaderRanker/gpu_requirements.txt
+++ b/jinahub/rankers/DPRReaderRanker/gpu_requirements.txt
@@ -1,0 +1,3 @@
+torch==1.9.0
+transformers==4.9.1
+jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/rankers/DPRReaderRanker/requirements.txt
+++ b/jinahub/rankers/DPRReaderRanker/requirements.txt
@@ -1,3 +1,4 @@
-torch==1.9.0
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.9.0+cpu
 transformers==4.9.1
 jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/rankers/DPRReaderRanker/tests/conftest.py
+++ b/jinahub/rankers/DPRReaderRanker/tests/conftest.py
@@ -1,0 +1,24 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def docker_image_name() -> str:
+    return Path(__file__).parents[1].stem.lower()
+
+
+@pytest.fixture(scope='session')
+def build_docker_image(docker_image_name: str) -> str:
+    subprocess.run(['docker', 'build', '-t', docker_image_name, '.'], check=True)
+    return docker_image_name
+
+
+@pytest.fixture(scope='session')
+def build_docker_image_gpu(docker_image_name: str) -> str:
+    image_name = f'{docker_image_name}:gpu'
+    subprocess.run(
+        ['docker', 'build', '-t', image_name, '-f', 'Dockerfile.gpu', '.'], check=True
+    )
+    return image_name

--- a/jinahub/rankers/DPRReaderRanker/tests/integration/test_with_flow.py
+++ b/jinahub/rankers/DPRReaderRanker/tests/integration/test_with_flow.py
@@ -1,6 +1,8 @@
 __copyright__ = "Copyright (c) 2020-2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
+import subprocess
+
 import pytest
 from jina import Document, DocumentArray, Flow
 
@@ -27,3 +29,32 @@ def test_integration(request_size: int):
         )
 
     assert sum(len(resp_batch.docs) for resp_batch in resp) == 50
+
+
+@pytest.mark.docker
+def test_docker_runtime(build_docker_image: str):
+    with pytest.raises(subprocess.TimeoutExpired):
+        subprocess.run(
+            ['jina', 'executor', f'--uses=docker://{build_docker_image}'],
+            timeout=30,
+            check=True,
+        )
+
+
+@pytest.mark.gpu
+@pytest.mark.docker
+def test_docker_runtime_gpu(build_docker_image_gpu: str):
+    with pytest.raises(subprocess.TimeoutExpired):
+        subprocess.run(
+            [
+                'jina',
+                'pea',
+                f'--uses=docker://{build_docker_image_gpu}',
+                '--gpus',
+                'all',
+                '--uses-with',
+                'device:cuda',
+            ],
+            timeout=30,
+            check=True,
+        )

--- a/jinahub/rankers/DPRReaderRanker/tests/unit/test_ranker.py
+++ b/jinahub/rankers/DPRReaderRanker/tests/unit/test_ranker.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 import pytest
 import torch
@@ -117,11 +116,11 @@ def test_spans_title_match(
             assert match_text in title_text_dict[match.tags['title']].lower()
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason='GPU is needed for this test')
+@pytest.mark.gpu
 @pytest.mark.parametrize('example_docs', [2], indirect=['example_docs'])
 def test_ranking_gpu(example_docs: DocumentArray):
 
-    ranker = DPRReaderRanker(device='gpu')
+    ranker = DPRReaderRanker(device='cuda')
     ranker.rank(example_docs, {})
 
     assert len(example_docs[0].matches) == 20

--- a/jinahub/rankers/DPRReaderRanker/tests/unit/test_ranker.py
+++ b/jinahub/rankers/DPRReaderRanker/tests/unit/test_ranker.py
@@ -121,6 +121,7 @@ def test_spans_title_match(
 def test_ranking_gpu(example_docs: DocumentArray):
 
     ranker = DPRReaderRanker(device='cuda')
+    assert ranker.model.device.type == 'cuda'
     ranker.rank(example_docs, {})
 
     assert len(example_docs[0].matches) == 20


### PR DESCRIPTION
This is part of https://github.com/jina-ai/executors/issues/169

It splits the DPRReaderRanker into cpu/gpu versions.
Also I noticed that the GPU test was actually failing, because the Tokenizer was generating tensors always on CPU device. With this PR it can also generate GPU based tensors. The results always have to be copied to CPU then to further process them on the CPU