### PR TITLE
feat(gpu): split TorchObjectDetectionSegmenter in cpu and gpu

### DIFF
--- a/jinahub/segmenters/TorchObjectDetectionSegmenter/Dockerfile.gpu
+++ b/jinahub/segmenters/TorchObjectDetectionSegmenter/Dockerfile.gpu
@@ -1,0 +1,10 @@
+FROM jinaai/jina:2-py37-perf
+
+RUN apt update && apt install -y git
+COPY gpu_requirements.txt gpu_requirements.txt
+RUN pip install --no-cache-dir -r gpu_requirements.txt
+
+COPY . /workdir/
+WORKDIR /workdir
+
+ENTRYPOINT ["jina", "executor", "--uses", "config.yml"]

--- a/jinahub/segmenters/TorchObjectDetectionSegmenter/gpu_requirements.txt
+++ b/jinahub/segmenters/TorchObjectDetectionSegmenter/gpu_requirements.txt
@@ -1,0 +1,3 @@
+torch==1.8.1
+torchvision==0.9.1
+jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/segmenters/TorchObjectDetectionSegmenter/requirements.txt
+++ b/jinahub/segmenters/TorchObjectDetectionSegmenter/requirements.txt
@@ -1,3 +1,4 @@
-torch==1.8.1
-torchvision==0.9.1
+-f https://download.pytorch.org/whl/torch_stable.html
+torch==1.8.1+cpu
+torchvision==0.9.1+cpu
 jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/segmenters/TorchObjectDetectionSegmenter/tests/conftest.py
+++ b/jinahub/segmenters/TorchObjectDetectionSegmenter/tests/conftest.py
@@ -1,0 +1,24 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope='session')
+def docker_image_name() -> str:
+    return Path(__file__).parents[1].stem.lower()
+
+
+@pytest.fixture(scope='session')
+def build_docker_image(docker_image_name: str) -> str:
+    subprocess.run(['docker', 'build', '-t', docker_image_name, '.'], check=True)
+    return docker_image_name
+
+
+@pytest.fixture(scope='session')
+def build_docker_image_gpu(docker_image_name: str) -> str:
+    image_name = f'{docker_image_name}:gpu'
+    subprocess.run(
+        ['docker', 'build', '-t', image_name, '-f', 'Dockerfile.gpu', '.'], check=True
+    )
+    return image_name

--- a/jinahub/segmenters/TorchObjectDetectionSegmenter/tests/integration/test_exec.py
+++ b/jinahub/segmenters/TorchObjectDetectionSegmenter/tests/integration/test_exec.py
@@ -1,6 +1,9 @@
 __copyright__ = "Copyright (c) 2020-2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
+import subprocess
+
+import pytest
 from jina import Document, Flow
 
 from ...torch_object_detection_segmenter import TorchObjectDetectionSegmenter
@@ -11,3 +14,32 @@ def test_exec():
     with f:
         resp = f.post(on='/test', inputs=Document(), return_results=True)
         assert resp is not None
+
+
+@pytest.mark.docker
+def test_docker_runtime(build_docker_image: str):
+    with pytest.raises(subprocess.TimeoutExpired):
+        subprocess.run(
+            ['jina', 'executor', f'--uses=docker://{build_docker_image}'],
+            timeout=30,
+            check=True,
+        )
+
+
+@pytest.mark.gpu
+@pytest.mark.docker
+def test_docker_runtime_gpu(build_docker_image_gpu: str):
+    with pytest.raises(subprocess.TimeoutExpired):
+        subprocess.run(
+            [
+                'jina',
+                'pea',
+                f'--uses=docker://{build_docker_image_gpu}',
+                '--gpus',
+                'all',
+                '--uses-with',
+                'device:cuda',
+            ],
+            timeout=30,
+            check=True,
+        )

--- a/jinahub/segmenters/TorchObjectDetectionSegmenter/torch_object_detection_segmenter.py
+++ b/jinahub/segmenters/TorchObjectDetectionSegmenter/torch_object_detection_segmenter.py
@@ -150,9 +150,13 @@ class TorchObjectDetectionSegmenter(Executor):
         self.label_name_map = (
             label_name_map or TorchObjectDetectionSegmenter.COCO_INSTANCE_CATEGORY_NAMES
         )
-        self.model = getattr(detection_models, self.model_name)(
-            pretrained=True, pretrained_backbone=True
-        ).eval()
+        self.model = (
+            getattr(detection_models, self.model_name)(
+                pretrained=True, pretrained_backbone=True
+            )
+            .to('cuda' if self.on_gpu else 'cpu')
+            .eval()
+        )
 
     def _predict(self, batch: List[np.ndarray]) -> 'np.ndarray':
         """


### PR DESCRIPTION
This is part of #169

It splits the TorchObjectDetectionSegmenter into cpu/gpu versions.
Also the previous device implementation was incomplete (not actually creating the model on GPU), this is fixed here