### PR TITLE
chore: rename args

### DIFF
--- a/jinahub/encoders/audio/AudioCLIPEncoder/tests/unit/test_exec.py
+++ b/jinahub/encoders/audio/AudioCLIPEncoder/tests/unit/test_exec.py
@@ -116,7 +116,7 @@ def test_traversal_paths():
         ]
     )
 
-    encoder = AudioCLIPEncoder(default_traversal_paths=['c'])
+    encoder = AudioCLIPEncoder(traversal_paths=['c'])
     encoder.encode(docs, parameters={})
     encoder.encode(docs, parameters={'traversal_paths': ['cc']})
     for path, count in [['r', 0], ['c', 6], ['cc', 3]]:

--- a/jinahub/encoders/audio/VGGISHAudioEncoder/executor/vggish_audio_encoder.py
+++ b/jinahub/encoders/audio/VGGISHAudioEncoder/executor/vggish_audio_encoder.py
@@ -28,20 +28,22 @@ class VggishAudioEncoder(Executor):
     def __init__(
         self,
         model_path: str = Path(cur_dir) / 'models',
-        default_traversal_paths: Optional[Iterable[str]] = None,
+        traversal_paths: Optional[Iterable[str]] = None,
         device: str = '/CPU:0',
         *args,
         **kwargs,
     ):
         """
-        :param model_path: path of the models directory
-        :param default_traversal_paths: fallback batch size in case there is not
+        :param model_path: path of the models directory. The directory should contain
+            'vggish_model.ckpt' and 'vggish_pca_params.ckpt'. Setting this to a new directory
+            will download the files.
+        :param traversal_paths: fallback batch size in case there is not
             batch size sent in the request
         :param device: device to run the model on e.g. '/CPU:0','/GPU:0','/GPU:2'
         """
 
         super().__init__(*args, **kwargs)
-        self.default_traversal_paths = default_traversal_paths or ['r']
+        self.traversal_paths = traversal_paths or ['r']
         self.logger = JinaLogger(self.__class__.__name__)
         self.device = device
         self.model_path = Path(model_path)
@@ -131,9 +133,7 @@ class VggishAudioEncoder(Executor):
     def _get_input_data(self, docs: DocumentArray, parameters: dict):
         """Create a filtered set of Documents to iterate over."""
 
-        traversal_paths = parameters.get(
-            'traversal_paths', self.default_traversal_paths
-        )
+        traversal_paths = parameters.get('traversal_paths', self.traversal_paths)
 
         # traverse thought all documents which have to be processed
         flat_docs = docs.traverse_flat(traversal_paths)

--- a/jinahub/encoders/video/VideoTorchEncoder/tests/unit/test_video_torch_encoder.py
+++ b/jinahub/encoders/video/VideoTorchEncoder/tests/unit/test_video_torch_encoder.py
@@ -14,13 +14,13 @@ from video_torch_encoder import ConvertFCHWtoCFHW, ConvertFHWCtoFCHW, VideoTorch
 
 def test_config():
     ex = Executor.load_config(str(Path(__file__).parents[2] / 'config.yml'))
-    assert ex.default_batch_size == 32
+    assert ex.batch_size == 32
 
 
 @pytest.mark.parametrize('model_name', ['r3d_18', 'mc3_18', 'r2plus1d_18'])
 def test_video_torch_encoder(model_name):
     ex = VideoTorchEncoder(
-        model_name=model_name, use_default_preprocessing=False, download_progress=False
+        model_name=model_name, use_preprocessing=False, download_progress=False
     )
     da = DocumentArray(
         [Document(blob=np.random.random((3, 2, 224, 224))) for _ in range(10)]
@@ -33,7 +33,7 @@ def test_video_torch_encoder(model_name):
 
 @pytest.mark.parametrize('batch_size', [1, 3, 10])
 def test_video_torch_encoder_traversal_paths(batch_size):
-    ex = VideoTorchEncoder(use_default_preprocessing=False, download_progress=False)
+    ex = VideoTorchEncoder(use_preprocessing=False, download_progress=False)
 
     def _create_doc_with_video_chunks():
         d = Document(blob=np.random.random((3, 2, 112, 112)))
@@ -51,9 +51,9 @@ def test_video_torch_encoder_traversal_paths(batch_size):
 
 
 @pytest.mark.parametrize('model_name', ['r3d_18', 'mc3_18', 'r2plus1d_18'])
-def test_video_torch_encoder_use_default_preprocessing(model_name):
+def test_video_torch_encoder_use_preprocessing(model_name):
     ex = VideoTorchEncoder(
-        model_name=model_name, use_default_preprocessing=True, download_progress=False
+        model_name=model_name, use_preprocessing=True, download_progress=False
     )
     da = DocumentArray(
         [Document(blob=np.random.random((10, 270, 480, 3))) for _ in range(10)]
@@ -81,7 +81,7 @@ def test_with_dataset_video(model_name, kinects_videos):
     )
 
     ex = VideoTorchEncoder(
-        use_default_preprocessing=True,
+        use_preprocessing=True,
         model_name=model_name,
         download_progress=False,
     )
@@ -128,10 +128,10 @@ def test_with_dataset_video(model_name, kinects_videos):
 
 @pytest.mark.parametrize('model_name', ['r3d_18', 'mc3_18', 'r2plus1d_18'])
 @pytest.mark.gpu
-def test_video_torch_encoder_use_default_preprocessing_gpu(model_name):
+def test_video_torch_encoder_use_preprocessing_gpu(model_name):
     ex = VideoTorchEncoder(
         model_name=model_name,
-        use_default_preprocessing=True,
+        use_preprocessing=True,
         device='cuda',
         download_progress=False,
     )


### PR DESCRIPTION
For `encoders/audio`, `encoders/video`
- [x] rename `default_traversal_paths` to `traversal_paths`
- [x] rename `default_batch_size` to `batch_size`
- [x] keep the args in the order `traversal_paths`, `batch_size`, `device`, `*args`, `**kwargs`