### PR TITLE
chore: rename args

### DIFF
--- a/jinahub/encoders/image/AudioCLIPImageEncoder/tests/unit/test_encoder.py
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/tests/unit/test_encoder.py
@@ -18,7 +18,7 @@ def basic_encoder() -> AudioCLIPImageEncoder:
 
 @pytest.fixture(scope="module")
 def basic_encoder_no_pre() -> AudioCLIPImageEncoder:
-    return AudioCLIPImageEncoder(use_default_preprocessing=False)
+    return AudioCLIPImageEncoder(use_preprocessing=False)
 
 
 @pytest.fixture(scope="function")
@@ -40,9 +40,9 @@ def nested_docs() -> DocumentArray:
 
 def test_config():
     ex = Executor.load_config(str(Path(__file__).parents[2] / 'config.yml'))
-    assert ex.default_batch_size == 32
-    assert ex.default_traversal_paths == ('r',)
-    assert ex.use_default_preprocessing
+    assert ex.batch_size == 32
+    assert ex.traversal_paths == ('r',)
+    assert ex.use_preprocessing
 
 
 def test_no_documents(basic_encoder):
@@ -65,14 +65,14 @@ def test_docs_no_blobs(basic_encoder):
 def test_err_preprocessing(basic_encoder):
     docs = DocumentArray([Document(blob=np.ones((3, 100, 100), dtype=np.uint8))])
 
-    with pytest.raises(ValueError, match='If `use_default_preprocessing=True`'):
+    with pytest.raises(ValueError, match='If `use_preprocessing=True`'):
         basic_encoder.encode(docs, {})
 
 
 def test_err_no_preprocessing(basic_encoder_no_pre):
     docs = DocumentArray([Document(blob=np.ones((100, 100, 3), dtype=np.uint8))])
 
-    with pytest.raises(ValueError, match='If `use_default_preprocessing=False`'):
+    with pytest.raises(ValueError, match='If `use_preprocessing=False`'):
         basic_encoder_no_pre.encode(docs, {})
 
 

--- a/jinahub/encoders/image/BigTransferEncoder/big_transfer.py
+++ b/jinahub/encoders/image/BigTransferEncoder/big_transfer.py
@@ -32,10 +32,10 @@ class BigTransferEncoder(Executor):
         self,
         model_path: Optional[str] = 'pretrained',
         model_name: Optional[str] = 'Imagenet21k/R50x1',
-        device: str = '/CPU:0',
         target_dim: Optional[Tuple[int, int, int]] = None,
         traversal_paths: Sequence[str] = ('r',),
         batch_size: int = 32,
+        device: str = '/CPU:0',
         *args,
         **kwargs,
     ):
@@ -61,11 +61,11 @@ class BigTransferEncoder(Executor):
             └── variables
                 ├── variables.data-00000-of-00001
                 └── variables.index
-        :param device: Device ('/CPU:0', '/GPU:0', '/GPU:X')
         :param target_dim: preprocess the data image into shape of `target_dim`,
             (e.g. (256, 256, 3) ), if set to None then preoprocessing will not be conducted
         :param traversal_paths: Traversal path through the docs
         :param batch_size: Batch size to be used in the encoder model
+        :param device: Device ('/CPU:0', '/GPU:0', '/GPU:X')
         """
         super().__init__(*args, **kwargs)
         self.model_path = model_path
@@ -135,7 +135,9 @@ class BigTransferEncoder(Executor):
         self.logger.info(f'Completed download of {self.model_name} BiT model')
 
     @requests
-    def encode(self, docs: DocumentArray, parameters: Dict, **kwargs):
+    def encode(
+        self, docs: Optional[DocumentArray] = None, parameters: Dict = {}, **kwargs
+    ):
         """
         Encode data into a ndarray of `B x D`.
         Where `B` is the batch size and `D` is the Dimension.
@@ -143,6 +145,8 @@ class BigTransferEncoder(Executor):
         :param docs: DocumentArray containing image data as an array
         :param parameters: parameters dictionary
         """
+        if not docs:
+            return
         docs_batch_generator = get_docs_batch_generator(
             docs,
             traversal_path=parameters.get(

--- a/jinahub/encoders/image/ImageTFEncoder/tests/unit/test_tfe.py
+++ b/jinahub/encoders/image/ImageTFEncoder/tests/unit/test_tfe.py
@@ -166,7 +166,7 @@ def test_image_results(test_images: Dict[str, np.array]):
 
 
 @pytest.mark.gpu
-def test_image_results_gpu(test_images: Dict[str, np.array]):
+def test_image_results_gpu():
     num_doc = 2
     test_data = np.random.rand(num_doc, _INPUT_DIM, _INPUT_DIM, 3)
     doc = DocumentArray()


### PR DESCRIPTION
for `encoders/image`
- [x] rename `default_traversal_paths` to `traversal_paths`
- [x] rename `default_batch_size` to `batch_size`
- [x] keep the args in the order `traversal_paths`, `batch_size`, `device`, `*args`, `**kwargs`

`CLIPImageEncoder` is not included because this might cause breaking changes for the EAP and showcases. I'll leave it for next week.