### PR TITLE
chore: rename args

### DIFF
--- a/jinahub/encoders/text/AudioCLIPTextEncoder/executor/audioclip_text.py
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/executor/audioclip_text.py
@@ -19,17 +19,17 @@ class AudioCLIPTextEncoder(Executor):
         self,
         model_path: str = '.cache/AudioCLIP-Full-Training.pt',
         tokenizer_path: str = '.cache/bpe_simple_vocab_16e6.txt.gz',
-        default_traversal_paths: Iterable[str] = ('r',),
-        default_batch_size: int = 32,
+        traversal_paths: Iterable[str] = ('r',),
+        batch_size: int = 32,
         device: str = 'cpu',
         *args,
         **kwargs
     ):
         """
         :param model_path: path to the pre-trained AudioCLIP model.
-        :param default_traversal_paths: default traversal path (used if not specified in
+        :param traversal_paths: default traversal path (used if not specified in
             request's parameters)
-        :param default_batch_size: default batch size (used if not specified in
+        :param batch_size: default batch size (used if not specified in
             request's parameters)
         :param device: device that the model is on (should be "cpu", "cuda" or "cuda:X",
             where X is the index of the GPU on the machine)
@@ -43,15 +43,19 @@ class AudioCLIPTextEncoder(Executor):
             .to(device)
             .eval()
         )
-        self.default_traversal_paths = default_traversal_paths
-        self.default_batch_size = default_batch_size
+        self.traversal_paths = traversal_paths
+        self.batch_size = batch_size
 
     @requests
     def encode(
-        self, docs: Optional[DocumentArray], parameters: dict, *args, **kwargs
+        self,
+        docs: Optional[DocumentArray] = None,
+        parameters: dict = {},
+        *args,
+        **kwargs
     ) -> None:
         """
-        Method to create embedddings for documents by encoding their text.
+        Method to create embeddings for documents by encoding their text.
 
         :param docs: A document array with documents to create embeddings for. Only the
             documents that have the ``text`` attribute will get embeddings.
@@ -59,13 +63,13 @@ class AudioCLIPTextEncoder(Executor):
             The accepted keys are ``traversal_paths`` and ``batch_size`` - in their
             absence their corresponding default values are used.
         """
+        if not docs:
+            return
 
         batch_generator = get_docs_batch_generator(
             docs,
-            traversal_path=parameters.get(
-                'traversal_paths', self.default_traversal_paths
-            ),
-            batch_size=parameters.get('batch_size', self.default_batch_size),
+            traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+            batch_size=parameters.get('batch_size', self.batch_size),
             needs_attr='text',
         )
 

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/tests/unit/test_encoder.py
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/tests/unit/test_encoder.py
@@ -30,7 +30,7 @@ def test_config():
             ),
         },
     )
-    assert ex.default_batch_size == 32
+    assert ex.batch_size == 32
 
 
 def test_no_document(basic_encoder: AudioCLIPTextEncoder):

--- a/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
+++ b/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
@@ -29,8 +29,8 @@ class DPRTextEncoder(Executor):
         base_tokenizer_model: Optional[str] = None,
         title_tag_key: Optional[str] = None,
         max_length: Optional[int] = None,
-        default_batch_size: int = 32,
-        default_traversal_paths: Iterable[str] = ('r',),
+        traversal_paths: Iterable[str] = ('r',),
+        batch_size: int = 32,
         device: str = 'cpu',
         *args,
         **kwargs,
@@ -50,10 +50,10 @@ class DPRTextEncoder(Executor):
             tag property. It is recommended to set this property for context encoders,
             to match the model pre-training. It has no effect for question encoders.
         :param max_length: Max length argument for the tokenizer
-        :param default_batch_size: Default batch size for encoding, used if the
-            batch size is not passed as a parameter with the request.
-        :param default_traversal_paths: Default traversal paths for encoding, used if the
+        :param traversal_paths: Default traversal paths for encoding, used if the
             traversal path is not passed as a parameter with the request.
+        :param batch_size: Default batch size for encoding, used if the
+            batch size is not passed as a parameter with the request.
         :param device: The device (cpu or gpu) that the model should be on.
         """
         super().__init__(*args, **kwargs)
@@ -95,11 +95,13 @@ class DPRTextEncoder(Executor):
 
         self.model = self.model.to(self.device).eval()
 
-        self.default_traversal_paths = default_traversal_paths
-        self.default_batch_size = default_batch_size
+        self.default_traversal_paths = traversal_paths
+        self.default_batch_size = batch_size
 
     @requests
-    def encode(self, docs: Optional[DocumentArray], parameters: dict, **kwargs):
+    def encode(
+        self, docs: Optional[DocumentArray] = None, parameters: dict = {}, **kwargs
+    ):
         """
         Encode all docs with text and store the encodings in the embedding
         attribute of the docs.

--- a/jinahub/encoders/text/FlairTextEncoder/tests/unit/test_encode.py
+++ b/jinahub/encoders/text/FlairTextEncoder/tests/unit/test_encode.py
@@ -15,7 +15,7 @@ def basic_encoder() -> FlairTextEncoder:
 
 def test_config():
     ex = Executor.load_config(str(Path(__file__).parents[2] / 'config.yml'))
-    assert ex.default_batch_size == 32
+    assert ex.batch_size == 32
 
 
 def test_no_document(basic_encoder: FlairTextEncoder):

--- a/jinahub/encoders/text/LaserEncoder/tests/unit/test_exec.py
+++ b/jinahub/encoders/text/LaserEncoder/tests/unit/test_exec.py
@@ -18,7 +18,7 @@ def basic_encoder() -> LaserEncoder:
 
 def test_config():
     ex = Executor.load_config(str(Path(__file__).parents[2] / 'config.yml'))
-    assert ex.default_language == 'en'
+    assert ex.language == 'en'
 
 
 def test_no_document(basic_encoder: LaserEncoder):

--- a/jinahub/encoders/text/TFIDFTextEncoder/tfidf_text_executor.py
+++ b/jinahub/encoders/text/TFIDFTextEncoder/tfidf_text_executor.py
@@ -16,15 +16,15 @@ class TFIDFTextEncoder(Executor):
     def __init__(
         self,
         path_vectorizer: Optional[str] = None,
-        default_batch_size: int = 2048,
-        default_traversal_paths: Tuple[str] = ('r',),
+        batch_size: int = 2048,
+        traversal_paths: Tuple[str] = ('r',),
         *args,
         **kwargs,
     ):
         """
         :param path_vectorizer: path of the pre-trained tfidf sklearn vectorizer
-        :param default_traversal_paths: fallback traversal path in case there is not traversal path sent in the request
-        :param default_batch_size: fallback batch size in case there is not batch size sent in the request
+        :param traversal_paths: fallback traversal path in case there is not traversal path sent in the request
+        :param batch_size: fallback batch size in case there is not batch size sent in the request
         """
         super().__init__(*args, **kwargs)
         if path_vectorizer is None:
@@ -33,8 +33,8 @@ class TFIDFTextEncoder(Executor):
             )
 
         self.path_vectorizer = path_vectorizer
-        self.default_batch_size = default_batch_size
-        self.default_traversal_paths = default_traversal_paths
+        self.batch_size = batch_size
+        self.traversal_paths = traversal_paths
 
         if os.path.exists(self.path_vectorizer):
             self.tfidf_vectorizer = pickle.load(open(self.path_vectorizer, 'rb'))
@@ -44,7 +44,9 @@ class TFIDFTextEncoder(Executor):
             )
 
     @requests
-    def encode(self, docs: Optional[DocumentArray], parameters: dict, **kwargs):
+    def encode(
+        self, docs: Optional[DocumentArray] = None, parameters: dict = {}, **kwargs
+    ):
         """
         Generate the TF-IDF feature vector for all text documents.
 
@@ -58,10 +60,8 @@ class TFIDFTextEncoder(Executor):
         if docs:
             document_batches_generator = get_docs_batch_generator(
                 docs,
-                traversal_path=parameters.get(
-                    'traversal_paths', self.default_traversal_paths
-                ),
-                batch_size=parameters.get('batch_size', self.default_batch_size),
+                traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+                batch_size=parameters.get('batch_size', self.batch_size),
                 needs_attr='text',
             )
 

--- a/jinahub/encoders/text/TextPaddleEncoder/tests/unit/test_text_paddle.py
+++ b/jinahub/encoders/text/TextPaddleEncoder/tests/unit/test_text_paddle.py
@@ -29,7 +29,7 @@ def parameters():
 
 def test_config():
     ex = Executor.load_config(str(Path(__file__).parents[2] / 'config.yml'))
-    assert ex.default_batch_size == 32
+    assert ex.batch_size == 32
 
 
 def test_text_paddle(model, document_array, content, parameters):

--- a/jinahub/encoders/text/TransformerSentenceEncoder/sentence_encoder.py
+++ b/jinahub/encoders/text/TransformerSentenceEncoder/sentence_encoder.py
@@ -17,25 +17,27 @@ class TransformerSentenceEncoder(Executor):
     def __init__(
         self,
         model_name: str = 'all-MiniLM-L6-v2',
+        traversal_paths: Iterable[str] = ('r',),
+        batch_size: int = 32,
         device: str = 'cpu',
-        default_traversal_paths: Iterable[str] = ('r',),
-        default_batch_size: int = 32,
         *args,
         **kwargs
     ):
         """
         :param model_name: The name of the sentence transformer to be used
         :param device: Torch device to put the model on (e.g. 'cpu', 'cuda', 'cuda:1')
-        :param default_traversal_paths: Default traversal paths
-        :param default_batch_size: Batch size to be used in the encoder model
+        :param traversal_paths: Default traversal paths
+        :param batch_size: Batch size to be used in the encoder model
         """
         super().__init__(*args, **kwargs)
-        self.default_batch_size = default_batch_size
-        self.default_traversal_paths = default_traversal_paths
+        self.batch_size = batch_size
+        self.traversal_paths = traversal_paths
         self.model = SentenceTransformer(model_name, device=device)
 
     @requests
-    def encode(self, docs: Optional[DocumentArray], parameters: Dict, **kwargs):
+    def encode(
+        self, docs: Optional[DocumentArray] = None, parameters: Dict = {}, **kwargs
+    ):
         """
         Encode all docs with text and store the encodings in the ``embedding`` attribute
         of the docs.
@@ -46,10 +48,8 @@ class TransformerSentenceEncoder(Executor):
         """
         for batch in get_docs_batch_generator(
             docs,
-            traversal_path=parameters.get(
-                'traversal_paths', self.default_traversal_paths
-            ),
-            batch_size=parameters.get('batch_size', self.default_batch_size),
+            traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+            batch_size=parameters.get('batch_size', self.batch_size),
             needs_attr='text',
         ):
             texts = batch.get_attributes('text')


### PR DESCRIPTION
for `encoders/text`

- [x] rename `default_traversal_paths` to `traversal_paths`
- [x] rename `default_batch_size` to `batch_size`
- [x] keep the args in the order `traversal_paths`, `batch_size`, `device`, `*args`, `**kwargs`

`CLIPTextEncoder`, `TransformerTFTextEncoder`, `TransformerTorchEncoder` is not included because this might cause breaking changes for the EAP and showcases. I'll leave it for next week.