### PR TITLE
chore: remove jina commons

### DIFF
--- a/jinahub/encoders/audio/AudioCLIPEncoder/Dockerfile
+++ b/jinahub/encoders/audio/AudioCLIPEncoder/Dockerfile
@@ -1,7 +1,7 @@
 FROM jinaai/jina:2-py37-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git wget ffmpeg libsndfile-dev
+RUN apt-get -y update && apt-get install -y wget ffmpeg libsndfile-dev
 
 # install requirements before copying the workspace
 COPY requirements.txt requirements.txt

--- a/jinahub/encoders/audio/AudioCLIPEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/audio/AudioCLIPEncoder/Dockerfile.gpu
@@ -1,7 +1,7 @@
 FROM jinaai/jina:2-py37-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git wget ffmpeg libsndfile-dev
+RUN apt-get -y update && apt-get install -y wget ffmpeg libsndfile-dev
 
 # install requirements before copying the workspace
 COPY gpu_requirements.txt gpu_requirements.txt

--- a/jinahub/encoders/audio/AudioCLIPEncoder/README.md
+++ b/jinahub/encoders/audio/AudioCLIPEncoder/README.md
@@ -12,4 +12,4 @@ For more information, such as run executor on gpu, check out [documentation](htt
 - [AudioCLIPImageEncoder](https://hub.jina.ai/executor/3atsazub)
 
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/audio/AudioCLIPEncoder/executor/audio_clip_encoder.py
+++ b/jinahub/encoders/audio/AudioCLIPEncoder/executor/audio_clip_encoder.py
@@ -71,7 +71,7 @@ class AudioCLIPEncoder(Executor):
         traversal_paths = parameters.get('traversal_paths', self.traversal_paths)
         batch_size = parameters.get('batch_size', self.batch_size)
 
-        with torch.no_grad():
+        with torch.inference_mode():
             for batch in docs.batch(batch_size, traversal_paths):
                 self._create_embeddings(batch)
 

--- a/jinahub/encoders/audio/VGGISHAudioEncoder/Dockerfile
+++ b/jinahub/encoders/audio/VGGISHAudioEncoder/Dockerfile
@@ -1,7 +1,7 @@
 FROM jinaai/jina:2-py37-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git curl  && apt-get install -y libsndfile-dev
+RUN apt-get -y update && apt-get install -y curl && apt-get install -y libsndfile-dev
 
 # install requirements before copying the workspace
 COPY requirements.txt /requirements.txt

--- a/jinahub/encoders/audio/VGGISHAudioEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/audio/VGGISHAudioEncoder/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:11.2.1-cudnn8-runtime
 
-RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y python3.8 python3-pip git libsndfile-dev
+RUN apt update && DEBIAN_FRONTEND="noninteractive" apt install -y \
+    python3.8 python3-pip libsndfile-dev
 RUN JINA_PIP_INSTALL_PERF=1 pip install --no-cache-dir jina~=2.0
 
 COPY gpu_requirements.txt gpu_requirements.txt

--- a/jinahub/encoders/audio/VGGISHAudioEncoder/README.md
+++ b/jinahub/encoders/audio/VGGISHAudioEncoder/README.md
@@ -6,4 +6,4 @@ For more information, such as run executor on gpu, check out [documentation](htt
 The VGGish paper was originally published [here](https://research.google/pubs/pub45611/).
 
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/audio/VGGISHAudioEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/audio/VGGISHAudioEncoder/gpu_requirements.txt
@@ -1,4 +1,3 @@
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons
 resampy==0.2.2
 tensorflow==2.6.0
 numpy==1.19.3

--- a/jinahub/encoders/audio/VGGISHAudioEncoder/requirements.txt
+++ b/jinahub/encoders/audio/VGGISHAudioEncoder/requirements.txt
@@ -1,5 +1,4 @@
 tensorflow-cpu==2.6.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons
 resampy==0.2.2
 tf_slim==1.1.0
 six==1.15.0

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/Dockerfile
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/Dockerfile
@@ -1,7 +1,7 @@
 FROM jinaai/jina:2-py37-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git wget \
+RUN apt-get -y update && apt-get install -y wget \
     && rm -rf /var/lib/apt/lists/*
 
 # install requirements before copying the workspace

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/Dockerfile.gpu
@@ -1,7 +1,7 @@
 FROM jinaai/jina:2-py37-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git wget \
+RUN apt-get -y update && apt-get install -y wget \
     && rm -rf /var/lib/apt/lists/*
 
 # install requirements before copying the workspace

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/README.md
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/README.md
@@ -42,4 +42,4 @@ And then you will also need to pass the argument `model_path='.cache/AudioCLIP-P
 - [AudioCLIP paper](https://arxiv.org/abs/2106.13043)
 - [AudioCLIP GitHub Repository](https://github.com/AndreyGuzhov/AudioCLIP)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
@@ -5,7 +5,6 @@ from typing import Iterable, Optional
 
 import torch
 from jina import DocumentArray, Executor, requests
-from jina_commons.batching import get_docs_batch_generator
 from PIL import Image
 from torchvision import transforms
 
@@ -96,14 +95,13 @@ class AudioCLIPImageEncoder(Executor):
         if not docs:
             return
 
-        batch_generator = get_docs_batch_generator(
-            docs,
-            traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+        batch_generator = docs.batch(
+            traversal_paths=parameters.get('traversal_paths', self.traversal_paths),
             batch_size=parameters.get('batch_size', self.batch_size),
-            needs_attr='blob',
+            require_attr='blob',
         )
 
-        with torch.no_grad():
+        with torch.inference_mode():
             for batch in batch_generator:
                 images = []
                 for doc in batch:

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
@@ -112,7 +112,7 @@ class AudioCLIPImageEncoder(Executor):
                                 " be of the format [H, W, C], in the RGB format (C=3),"
                                 f" but got C={doc.blob.shape[2]} instead."
                             )
-                        images.append(self._default_transforms(doc.blob.copy()))
+                        images.append(self._default_transforms(doc.blob))
                     else:
                         if doc.blob.shape[0] != 3:
                             raise ValueError(

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
@@ -127,5 +127,4 @@ class AudioCLIPImageEncoder(Executor):
                 embeddings = self.model.encode_image(image=images.to(self.device))
                 embeddings = embeddings.cpu().numpy()
 
-                for idx, doc in enumerate(batch):
-                    doc.embedding = embeddings[idx]
+                batch.embeddings = embeddings

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/executor/audioclip_image.py
@@ -127,4 +127,5 @@ class AudioCLIPImageEncoder(Executor):
                 embeddings = self.model.encode_image(image=images.to(self.device))
                 embeddings = embeddings.cpu().numpy()
 
-                batch.embeddings = embeddings
+                for idx, doc in enumerate(batch):
+                    doc.embedding = embeddings[idx]

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/gpu_requirements.txt
@@ -1,4 +1,3 @@
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons
 torch==1.9.0
 torchvision
 pytorch-ignite==0.3.0

--- a/jinahub/encoders/image/AudioCLIPImageEncoder/requirements.txt
+++ b/jinahub/encoders/image/AudioCLIPImageEncoder/requirements.txt
@@ -1,4 +1,3 @@
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 torchvision

--- a/jinahub/encoders/image/CLIPImageEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/image/CLIPImageEncoder/Dockerfile.gpu
@@ -1,6 +1,5 @@
 FROM jinaai/jina:2-py37-perf
 
-RUN apt update && apt install -y git
 COPY gpu_requirements.txt gpu_requirements.txt
 RUN pip install --no-cache-dir -r gpu_requirements.txt
 

--- a/jinahub/encoders/image/CLIPImageEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/image/CLIPImageEncoder/Dockerfile.gpu
@@ -1,5 +1,6 @@
 FROM jinaai/jina:2-py37-perf
 
+RUN apt update && apt install -y git
 COPY gpu_requirements.txt gpu_requirements.txt
 RUN pip install --no-cache-dir -r gpu_requirements.txt
 

--- a/jinahub/encoders/image/CLIPImageEncoder/README.md
+++ b/jinahub/encoders/image/CLIPImageEncoder/README.md
@@ -8,4 +8,4 @@ For more information on the `gpu` usage and `volume` mounting, please refer to t
 For more information on CLIP model, please checkout the [blog post](https://openai.com/blog/clip/),
 [paper](https://arxiv.org/abs/2103.00020) and [hugging face documentation](https://huggingface.co/transformers/model_doc/clip.html)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/image/CLIPImageEncoder/clip_image.py
+++ b/jinahub/encoders/image/CLIPImageEncoder/clip_image.py
@@ -93,7 +93,7 @@ class CLIPImageEncoder(Executor):
 
         with torch.inference_mode():
             for batch_docs in document_batches_generator:
-                blob_batch = batch_docs.blobs
+                blob_batch = [d.blob for d in batch_docs]
                 if self.use_default_preprocessing:
                     tensor = self._generate_input_features(blob_batch.copy())
                 else:
@@ -107,7 +107,9 @@ class CLIPImageEncoder(Executor):
 
                 embeddings = self.model.get_image_features(**tensor)
                 embeddings = embeddings.cpu().numpy()
-                batch_docs.embeddings = embeddings
+
+                for doc, embed in zip(batch_docs, embeddings):
+                    doc.embedding = embed
 
     def _generate_input_features(self, images):
         input_tokens = self.preprocessor(

--- a/jinahub/encoders/image/CLIPImageEncoder/clip_image.py
+++ b/jinahub/encoders/image/CLIPImageEncoder/clip_image.py
@@ -95,13 +95,11 @@ class CLIPImageEncoder(Executor):
             for batch_docs in document_batches_generator:
                 blob_batch = [d.blob for d in batch_docs]
                 if self.use_default_preprocessing:
-                    tensor = self._generate_input_features(blob_batch.copy())
+                    tensor = self._generate_input_features(blob_batch)
                 else:
                     tensor = {
                         "pixel_values": torch.tensor(
-                            blob_batch.copy(),
-                            dtype=torch.float32,
-                            device=self.device,
+                            blob_batch, dtype=torch.float32, device=self.device
                         )
                     }
 

--- a/jinahub/encoders/image/CLIPImageEncoder/clip_image.py
+++ b/jinahub/encoders/image/CLIPImageEncoder/clip_image.py
@@ -93,7 +93,7 @@ class CLIPImageEncoder(Executor):
 
         with torch.inference_mode():
             for batch_docs in document_batches_generator:
-                blob_batch = [d.blob for d in batch_docs]
+                blob_batch = batch_docs.blobs
                 if self.use_default_preprocessing:
                     tensor = self._generate_input_features(blob_batch.copy())
                 else:
@@ -107,9 +107,7 @@ class CLIPImageEncoder(Executor):
 
                 embeddings = self.model.get_image_features(**tensor)
                 embeddings = embeddings.cpu().numpy()
-
-                for doc, embed in zip(batch_docs, embeddings):
-                    doc.embedding = embed
+                batch_docs.embeddings = embeddings
 
     def _generate_input_features(self, images):
         input_tokens = self.preprocessor(

--- a/jinahub/encoders/image/CLIPImageEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/image/CLIPImageEncoder/gpu_requirements.txt
@@ -1,4 +1,3 @@
 torch==1.9.0
 torchvision==0.10.0
 transformers==4.9.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/image/CLIPImageEncoder/requirements.txt
+++ b/jinahub/encoders/image/CLIPImageEncoder/requirements.txt
@@ -2,4 +2,3 @@
 torch==1.9.0+cpu
 torchvision==0.10.0
 transformers==4.9.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/image/CLIPImageEncoder/tests/unit/test_clip.py
+++ b/jinahub/encoders/image/CLIPImageEncoder/tests/unit/test_clip.py
@@ -41,7 +41,7 @@ def nested_docs() -> DocumentArray:
 
 def test_config():
     ex = Executor.load_config(str(Path(__file__).parents[2] / 'config.yml'))
-    assert ex.default_batch_size == 32
+    assert ex.batch_size == 32
 
 
 def test_no_documents(encoder: CLIPImageEncoder):

--- a/jinahub/encoders/image/CustomImageTorchEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/image/CustomImageTorchEncoder/Dockerfile.gpu
@@ -1,6 +1,5 @@
 FROM jinaai/jina:2-py37-perf
 
-RUN apt update && apt install -y git
 COPY gpu_requirements.txt gpu_requirements.txt
 RUN pip install --no-cache-dir -r gpu_requirements.txt
 

--- a/jinahub/encoders/image/CustomImageTorchEncoder/README.md
+++ b/jinahub/encoders/image/CustomImageTorchEncoder/README.md
@@ -65,4 +65,4 @@ with f:
 ## Reference
 - https://pytorch.org/tutorials/beginner/saving_loading_models.html
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/image/CustomImageTorchEncoder/custom_image_torch_encoder.py
+++ b/jinahub/encoders/image/CustomImageTorchEncoder/custom_image_torch_encoder.py
@@ -6,7 +6,6 @@ import os
 import types
 from typing import Dict, Iterable, Optional
 
-import numpy as np
 import torch
 import torch.nn as nn
 from jina import DocumentArray, Executor, requests
@@ -123,12 +122,11 @@ class CustomImageTorchEncoder(Executor):
     def _create_embeddings(self, document_batches_generator: Iterable):
         with torch.inference_mode():
             for document_batch in document_batches_generator:
-                blob_batch = np.array([d.blob for d in document_batch])
+                blob_batch = document_batch.blobs
                 _input = torch.from_numpy(blob_batch.astype('float32'))
                 _input = _input.to(self.device)
                 _feature = self.adaptiveAvgPool2d(
                     self._get_features(content=_input).detach()
                 )
                 _feature = _feature.cpu().numpy()
-                for doc, embedding in zip(document_batch, _feature):
-                    doc.embedding = embedding.squeeze()
+                document_batch.embeddings = _feature

--- a/jinahub/encoders/image/CustomImageTorchEncoder/custom_image_torch_encoder.py
+++ b/jinahub/encoders/image/CustomImageTorchEncoder/custom_image_torch_encoder.py
@@ -6,6 +6,7 @@ import os
 import types
 from typing import Dict, Iterable, Optional
 
+import numpy as np
 import torch
 import torch.nn as nn
 from jina import DocumentArray, Executor, requests
@@ -122,11 +123,12 @@ class CustomImageTorchEncoder(Executor):
     def _create_embeddings(self, document_batches_generator: Iterable):
         with torch.inference_mode():
             for document_batch in document_batches_generator:
-                blob_batch = document_batch.blobs
+                blob_batch = np.array([d.blob for d in document_batch])
                 _input = torch.from_numpy(blob_batch.astype('float32'))
                 _input = _input.to(self.device)
                 _feature = self.adaptiveAvgPool2d(
                     self._get_features(content=_input).detach()
                 )
                 _feature = _feature.cpu().numpy()
-                document_batch.embeddings = _feature
+                for doc, embedding in zip(document_batch, _feature):
+                    doc.embedding = embedding.squeeze()

--- a/jinahub/encoders/image/CustomImageTorchEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/image/CustomImageTorchEncoder/gpu_requirements.txt
@@ -1,3 +1,2 @@
 torch==1.9.0
 torchvision==0.10.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/image/CustomImageTorchEncoder/requirements.txt
+++ b/jinahub/encoders/image/CustomImageTorchEncoder/requirements.txt
@@ -1,4 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 torchvision==0.10.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/image/ImagePaddlehubEncoder/README.md
+++ b/jinahub/encoders/image/ImagePaddlehubEncoder/README.md
@@ -2,4 +2,4 @@
 
 **ImagePaddlehubEncoder** encodes `Document` content from a ndarray, potentially B x (Channel x Height x Width) into a ndarray of `B x D`. Internally, **ImagePaddlehubEncoder** wraps the models from [paddlehub](https://github.com/PaddlePaddle/PaddleHub)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/image/ImagePaddlehubEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/image/ImagePaddlehubEncoder/gpu_requirements.txt
@@ -1,7 +1,6 @@
 paddlehub==1.8.2
 paddlepaddle-gpu==2.0
 six==1.15.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons
 pillow==8.2
 opencv-python-headless
 scipy

--- a/jinahub/encoders/image/ImagePaddlehubEncoder/paddle_image.py
+++ b/jinahub/encoders/image/ImagePaddlehubEncoder/paddle_image.py
@@ -105,8 +105,7 @@ class ImagePaddlehubEncoder(Executor):
 
     def _create_embeddings(self, document_batches_generator: Iterable):
         for document_batch in document_batches_generator:
-            blob_batch = [d.blob for d in document_batch]
-            blob_batch = np.array(blob_batch)
+            blob_batch = document_batch.embeddings.copy()
             if self.channel_axis != self._default_channel_axis:
                 blob_batch = np.moveaxis(
                     blob_batch, self.channel_axis, self._default_channel_axis
@@ -123,8 +122,7 @@ class ImagePaddlehubEncoder(Executor):
             else:
                 embedding_batch = self._get_pooling(feature_map)
 
-            for document, embedding in zip(document_batch, embedding_batch):
-                document.embedding = embedding
+            document_batch.embeddings = embedding_batch
 
     def _get_pooling(self, content: 'np.ndarray') -> 'np.ndarray':
         """Get ndarray with selected pooling strategy"""

--- a/jinahub/encoders/image/ImagePaddlehubEncoder/paddle_image.py
+++ b/jinahub/encoders/image/ImagePaddlehubEncoder/paddle_image.py
@@ -105,7 +105,8 @@ class ImagePaddlehubEncoder(Executor):
 
     def _create_embeddings(self, document_batches_generator: Iterable):
         for document_batch in document_batches_generator:
-            blob_batch = document_batch.embeddings.copy()
+            blob_batch = [d.blob for d in document_batch]
+            blob_batch = np.array(blob_batch)
             if self.channel_axis != self._default_channel_axis:
                 blob_batch = np.moveaxis(
                     blob_batch, self.channel_axis, self._default_channel_axis
@@ -122,7 +123,8 @@ class ImagePaddlehubEncoder(Executor):
             else:
                 embedding_batch = self._get_pooling(feature_map)
 
-            document_batch.embeddings = embedding_batch
+            for document, embedding in zip(document_batch, embedding_batch):
+                document.embedding = embedding
 
     def _get_pooling(self, content: 'np.ndarray') -> 'np.ndarray':
         """Get ndarray with selected pooling strategy"""

--- a/jinahub/encoders/image/ImagePaddlehubEncoder/paddle_image.py
+++ b/jinahub/encoders/image/ImagePaddlehubEncoder/paddle_image.py
@@ -5,7 +5,6 @@ from typing import Iterable, Optional, Tuple
 
 import numpy as np
 from jina import DocumentArray, Executor, requests
-from jina_commons.batching import get_docs_batch_generator
 
 
 class ImagePaddlehubEncoder(Executor):
@@ -97,11 +96,10 @@ class ImagePaddlehubEncoder(Executor):
             override the `self.traversal_paths` and `self.batch_size`.
         """
         if docs:
-            document_batches_generator = get_docs_batch_generator(
-                docs,
-                traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+            document_batches_generator = docs.batch(
+                traversal_paths=parameters.get('traversal_paths', self.traversal_paths),
                 batch_size=parameters.get('batch_size', self.batch_size),
-                needs_attr='blob',
+                require_attr='blob',
             )
             self._create_embeddings(document_batches_generator)
 

--- a/jinahub/encoders/image/ImagePaddlehubEncoder/requirements.txt
+++ b/jinahub/encoders/image/ImagePaddlehubEncoder/requirements.txt
@@ -1,7 +1,6 @@
 paddlehub==1.8.2
 paddlepaddle==2.0
 six==1.15.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons
 pillow==8.2
 opencv-python-headless
 scipy

--- a/jinahub/encoders/image/ImageTFEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/image/ImageTFEncoder/Dockerfile.gpu
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:11.2.1-cudnn8-runtime
 
-RUN apt update && apt install -y python3.8 python3-pip git
+RUN apt update && apt install -y python3.8 python3-pip
 RUN JINA_PIP_INSTALL_PERF=1 pip install --no-cache-dir jina~=2.0
 
 COPY gpu_requirements.txt gpu_requirements.txt

--- a/jinahub/encoders/image/ImageTFEncoder/README.md
+++ b/jinahub/encoders/image/ImageTFEncoder/README.md
@@ -5,4 +5,4 @@ Internally, `ImageTFEncoder` wraps the models from [tensorflow.keras.application
 
 For more information on the `gpu` usage and `volume` mounting, please refer to the [documentation](https://docs.jina.ai/tutorials/gpu-executor/).
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/image/ImageTFEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/image/ImageTFEncoder/gpu_requirements.txt
@@ -1,3 +1,2 @@
 tensorflow>=2.5.0
 Pillow==8.2.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/image/ImageTFEncoder/image_tf_encoder.py
+++ b/jinahub/encoders/image/ImageTFEncoder/image_tf_encoder.py
@@ -3,6 +3,7 @@ __license__ = "Apache-2.0"
 
 from typing import Dict, Iterable, Optional
 
+import numpy as np
 import tensorflow as tf
 from jina import DocumentArray, Executor, requests
 from jina.logging.logger import JinaLogger
@@ -102,6 +103,8 @@ class ImageTFEncoder(Executor):
 
     def _create_embeddings(self, document_batches_generator: Iterable):
         for document_batch in document_batches_generator:
-            blob_batch = document_batch.blobs.copy()
+            blob_batch = np.stack([d.blob for d in document_batch])
             with self.device:
-                document_batch.embeddings = self.model(blob_batch)
+                embedding_batch = self.model(blob_batch)
+            for document, embedding in zip(document_batch, embedding_batch):
+                document.embedding = np.array(embedding)

--- a/jinahub/encoders/image/ImageTFEncoder/image_tf_encoder.py
+++ b/jinahub/encoders/image/ImageTFEncoder/image_tf_encoder.py
@@ -7,7 +7,6 @@ import numpy as np
 import tensorflow as tf
 from jina import DocumentArray, Executor, requests
 from jina.logging.logger import JinaLogger
-from jina_commons.batching import get_docs_batch_generator
 
 
 class ImageTFEncoder(Executor):
@@ -95,11 +94,10 @@ class ImageTFEncoder(Executor):
             override the `self.traversal_paths` and `self.batch_size`.
         """
         if docs:
-            document_batches_generator = get_docs_batch_generator(
-                docs,
-                traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+            document_batches_generator = docs.batch(
+                traversal_paths=parameters.get('traversal_paths', self.traversal_paths),
                 batch_size=parameters.get('batch_size', self.batch_size),
-                needs_attr='blob',
+                require_attr='blob',
             )
             self._create_embeddings(document_batches_generator)
 

--- a/jinahub/encoders/image/ImageTFEncoder/image_tf_encoder.py
+++ b/jinahub/encoders/image/ImageTFEncoder/image_tf_encoder.py
@@ -3,7 +3,6 @@ __license__ = "Apache-2.0"
 
 from typing import Dict, Iterable, Optional
 
-import numpy as np
 import tensorflow as tf
 from jina import DocumentArray, Executor, requests
 from jina.logging.logger import JinaLogger
@@ -103,8 +102,6 @@ class ImageTFEncoder(Executor):
 
     def _create_embeddings(self, document_batches_generator: Iterable):
         for document_batch in document_batches_generator:
-            blob_batch = np.stack([d.blob for d in document_batch])
+            blob_batch = document_batch.blobs.copy()
             with self.device:
-                embedding_batch = self.model(blob_batch)
-            for document, embedding in zip(document_batch, embedding_batch):
-                document.embedding = np.array(embedding)
+                document_batch.embeddings = self.model(blob_batch)

--- a/jinahub/encoders/image/ImageTFEncoder/requirements.txt
+++ b/jinahub/encoders/image/ImageTFEncoder/requirements.txt
@@ -1,3 +1,2 @@
 tensorflow-cpu
 Pillow==8.2.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/image/TimmImageEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/image/TimmImageEncoder/Dockerfile.gpu
@@ -1,6 +1,5 @@
 FROM jinaai/jina:2-py37-perf
 
-RUN apt update && apt install -y git
 COPY gpu_requirements.txt gpu_requirements.txt
 RUN pip install --no-cache-dir -r gpu_requirements.txt
 

--- a/jinahub/encoders/image/TimmImageEncoder/README.md
+++ b/jinahub/encoders/image/TimmImageEncoder/README.md
@@ -3,7 +3,7 @@
 **TimmImageEncoder** encodes images (stored in the `blob` attribute od Documents) into 
 embeddings, using the models from [timm](https://rwightman.github.io/pytorch-image-models/).
 
-## 🔍️ Reference
+## Reference
 - [Timm Models](https://rwightman.github.io/pytorch-image-models/models/)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/image/TimmImageEncoder/tests/unit/test_unit.py
+++ b/jinahub/encoders/image/TimmImageEncoder/tests/unit/test_unit.py
@@ -40,7 +40,7 @@ def test_preprocessing_reshape_correct(content: np.ndarray, out_shape: Tuple):
 def test_encode_image_returns_correct_length(
     traversal_paths: Tuple[str], docs: DocumentArray
 ) -> None:
-    encoder = TimmImageEncoder(traversal_path=traversal_paths)
+    encoder = TimmImageEncoder(traversal_paths=traversal_paths)
 
     encoder.encode(docs=docs, parameters={})
 

--- a/jinahub/encoders/image/TimmImageEncoder/timm_encoder.py
+++ b/jinahub/encoders/image/TimmImageEncoder/timm_encoder.py
@@ -93,4 +93,7 @@ class TimmImageEncoder(Executor):
             with torch.inference_mode():
                 tensor = torch.from_numpy(images).to(self.device)
                 features = self._model(tensor)
-                document_batch.embeddings = features.cpu().numpy()
+                features = features.cpu().numpy()
+
+            for doc, embed in zip(document_batch, features):
+                doc.embedding = embed

--- a/jinahub/encoders/image/TimmImageEncoder/timm_encoder.py
+++ b/jinahub/encoders/image/TimmImageEncoder/timm_encoder.py
@@ -93,7 +93,4 @@ class TimmImageEncoder(Executor):
             with torch.inference_mode():
                 tensor = torch.from_numpy(images).to(self.device)
                 features = self._model(tensor)
-                features = features.cpu().numpy()
-
-            for doc, embed in zip(document_batch, features):
-                doc.embedding = embed
+                document_batch.embeddings = features.cpu().numpy()

--- a/jinahub/encoders/image/TimmImageEncoder/timm_encoder.py
+++ b/jinahub/encoders/image/TimmImageEncoder/timm_encoder.py
@@ -26,7 +26,7 @@ class TimmImageEncoder(Executor):
         self,
         model_name: str = 'resnet18',
         device: str = 'cpu',
-        traversal_path: Tuple[str] = ('r',),
+        traversal_paths: Tuple[str] = ('r',),
         batch_size: Optional[int] = 32,
         use_default_preprocessing: bool = True,
         *args,
@@ -51,11 +51,10 @@ class TimmImageEncoder(Executor):
         self.batch_size = batch_size
         self.use_default_preprocessing = use_default_preprocessing
 
-        self.traversal_path = traversal_path
+        self.traversal_paths = traversal_paths
 
         self._model = create_model(model_name, pretrained=True, num_classes=0)
-        self._model = self._model.to(device)
-        self._model.eval()
+        self._model = self._model.to(device).eval()
 
         config = resolve_data_config({}, model=self._model)
         self._preprocess = create_transform(**config)
@@ -76,7 +75,7 @@ class TimmImageEncoder(Executor):
         if docs is None:
             return
 
-        traversal_paths = parameters.get('traversal_paths', self.traversal_path)
+        traversal_paths = parameters.get('traversal_paths', self.traversal_paths)
         batch_size = parameters.get('batch_size', self.batch_size)
         docs_batch_generator = docs.batch(
             traversal_paths=traversal_paths,

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/Dockerfile.gpu
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/Dockerfile.gpu
@@ -1,7 +1,7 @@
 FROM jinaai/jina:2-py37-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git wget \
+RUN apt-get -y update && apt-get install -y wget \
     && rm -rf /var/lib/apt/lists/*
 
 # install requirements before copying the workspace

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/README.md
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/README.md
@@ -78,4 +78,4 @@ with f:
 - [AudioCLIP paper](https://arxiv.org/abs/2106.13043)
 - [AudioCLIP GitHub Repository](https://github.com/AndreyGuzhov/AudioCLIP)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/executor/audioclip_text.py
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/executor/audioclip_text.py
@@ -74,4 +74,7 @@ class AudioCLIPTextEncoder(Executor):
         with torch.inference_mode():
             for batch in batch_generator:
                 embeddings = self.model.encode_text(text=[[doc.text] for doc in batch])
-                batch.embeddings = embeddings.cpu().numpy()
+                embeddings = embeddings.cpu().numpy()
+
+                for idx, doc in enumerate(batch):
+                    doc.embedding = embeddings[idx]

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/executor/audioclip_text.py
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/executor/audioclip_text.py
@@ -74,7 +74,4 @@ class AudioCLIPTextEncoder(Executor):
         with torch.inference_mode():
             for batch in batch_generator:
                 embeddings = self.model.encode_text(text=[[doc.text] for doc in batch])
-                embeddings = embeddings.cpu().numpy()
-
-                for idx, doc in enumerate(batch):
-                    doc.embedding = embeddings[idx]
+                batch.embeddings = embeddings.cpu().numpy()

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/gpu_requirements.txt
@@ -1,4 +1,3 @@
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons
 torch==1.9.0
 torchvision
 pytorch-ignite==0.3.0

--- a/jinahub/encoders/text/AudioCLIPTextEncoder/requirements.txt
+++ b/jinahub/encoders/text/AudioCLIPTextEncoder/requirements.txt
@@ -1,4 +1,3 @@
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 

--- a/jinahub/encoders/text/DPRTextEncoder/README.md
+++ b/jinahub/encoders/text/DPRTextEncoder/README.md
@@ -12,4 +12,4 @@ This encoder supports both the DPR context and question encoders - you should sp
 - [DPR paper](https://arxiv.org/abs/2004.04906)
 - [Huggingface transformers DPR model documentation](https://huggingface.co/transformers/model_doc/dpr.html)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
+++ b/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
@@ -150,4 +150,7 @@ class DPRTextEncoder(Executor):
                     truncation=True,
                     return_tensors='pt',
                 ).to(self.device)
-                batch_docs.embeddings = self.model(**inputs).pooler_output.cpu().numpy()
+                embeddings = self.model(**inputs).pooler_output.cpu().numpy()
+
+            for doc, embedding in zip(batch_docs, embeddings):
+                doc.embedding = embedding

--- a/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
+++ b/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
@@ -150,7 +150,4 @@ class DPRTextEncoder(Executor):
                     truncation=True,
                     return_tensors='pt',
                 ).to(self.device)
-                embeddings = self.model(**inputs).pooler_output.cpu().numpy()
-
-            for doc, embedding in zip(batch_docs, embeddings):
-                doc.embedding = embedding
+                batch_docs.embeddings = self.model(**inputs).pooler_output.cpu().numpy()

--- a/jinahub/encoders/text/DPRTextEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/DPRTextEncoder/gpu_requirements.txt
@@ -1,3 +1,2 @@
 torch==1.9.0
 transformers==4.9.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/text/DPRTextEncoder/requirements.txt
+++ b/jinahub/encoders/text/DPRTextEncoder/requirements.txt
@@ -1,4 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 transformers==4.9.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/text/FlairTextEncoder/README.md
+++ b/jinahub/encoders/text/FlairTextEncoder/README.md
@@ -11,5 +11,5 @@ Due to different interfaces of all these embedding models, using custom pre-trai
 
 - [flair GitHub repository](https://github.com/flairNLP/flair)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->
 

--- a/jinahub/encoders/text/FlairTextEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/FlairTextEncoder/gpu_requirements.txt
@@ -1,3 +1,2 @@
 torch==1.9.0
 flair==0.8.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/jinahub/encoders/text/FlairTextEncoder/requirements.txt
+++ b/jinahub/encoders/text/FlairTextEncoder/requirements.txt
@@ -1,4 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 flair==0.8.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/jinahub/encoders/text/LaserEncoder/README.md
+++ b/jinahub/encoders/text/LaserEncoder/README.md
@@ -23,4 +23,4 @@ python -m laserembeddings download-models
 ## Reference
 - [LASER](https://github.com/facebookresearch/LASER#supported-languages) with the language code ([ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes))
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/LaserEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/LaserEncoder/gpu_requirements.txt
@@ -1,3 +1,2 @@
 torch==1.9.0
 laserembeddings[ja,zh]==1.1.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/jinahub/encoders/text/LaserEncoder/laser_encoder.py
+++ b/jinahub/encoders/text/LaserEncoder/laser_encoder.py
@@ -109,6 +109,6 @@ class LaserEncoder(Executor):
             text_batch = document_batch.texts
 
             language = parameters.get('language', self.language)
-            document_batch.embeddings = self.model.embed_sentences(
-                text_batch, lang=language
-            )
+            embeddings = self.model.embed_sentences(text_batch, lang=language)
+            for document, embedding in zip(document_batch, embeddings):
+                document.embedding = embedding

--- a/jinahub/encoders/text/LaserEncoder/laser_encoder.py
+++ b/jinahub/encoders/text/LaserEncoder/laser_encoder.py
@@ -109,6 +109,6 @@ class LaserEncoder(Executor):
             text_batch = document_batch.texts
 
             language = parameters.get('language', self.language)
-            embeddings = self.model.embed_sentences(text_batch, lang=language)
-            for document, embedding in zip(document_batch, embeddings):
-                document.embedding = embedding
+            document_batch.embeddings = self.model.embed_sentences(
+                text_batch, lang=language
+            )

--- a/jinahub/encoders/text/LaserEncoder/requirements.txt
+++ b/jinahub/encoders/text/LaserEncoder/requirements.txt
@@ -1,4 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 laserembeddings[ja,zh]==1.1.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/jinahub/encoders/text/LaserEncoder/tests/unit/test_exec.py
+++ b/jinahub/encoders/text/LaserEncoder/tests/unit/test_exec.py
@@ -100,13 +100,6 @@ def test_traversal_path(
         assert len(list(filter(lambda x: x is not None, embeddings))) == count
 
 
-def test_no_documents():
-    encoder = LaserEncoder()
-    docs = []
-    encoder.encode(docs, parameters={'batch_size': 10, 'traversal_paths': ['r']})
-    assert not docs
-
-
 @pytest.mark.parametrize('batch_size', [1, 2, 4, 8])
 def test_batch_size(basic_encoder: LaserEncoder, batch_size: int):
     docs = DocumentArray([Document(text='hello there') for _ in range(32)])

--- a/jinahub/encoders/text/SpacyTextEncoder/README.md
+++ b/jinahub/encoders/text/SpacyTextEncoder/README.md
@@ -6,4 +6,4 @@
 - https://spacy.io/models/
 - https://spacy.io/usage/models
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/SpacyTextEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/SpacyTextEncoder/gpu_requirements.txt
@@ -1,4 +1,3 @@
 spacy[cuda112]==3.1.2
 torch==1.9.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz#egg=en_core_web_sm

--- a/jinahub/encoders/text/SpacyTextEncoder/requirements.txt
+++ b/jinahub/encoders/text/SpacyTextEncoder/requirements.txt
@@ -1,2 +1,1 @@
 spacy==3.1.2
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/jinahub/encoders/text/SpacyTextEncoder/spacy_text_encoder.py
+++ b/jinahub/encoders/text/SpacyTextEncoder/spacy_text_encoder.py
@@ -75,7 +75,7 @@ class SpacyTextEncoder(Executor):
                 require_attr='text',
             )
             for document_batch in document_batches_generator:
-                texts = document_batch.texts
+                texts = [doc.text for doc in document_batch]
                 for doc, spacy_doc in zip(
                     document_batch, self.spacy_model.pipe(texts, batch_size=batch_size)
                 ):

--- a/jinahub/encoders/text/SpacyTextEncoder/spacy_text_encoder.py
+++ b/jinahub/encoders/text/SpacyTextEncoder/spacy_text_encoder.py
@@ -75,7 +75,7 @@ class SpacyTextEncoder(Executor):
                 require_attr='text',
             )
             for document_batch in document_batches_generator:
-                texts = [doc.text for doc in document_batch]
+                texts = document_batch.texts
                 for doc, spacy_doc in zip(
                     document_batch, self.spacy_model.pipe(texts, batch_size=batch_size)
                 ):

--- a/jinahub/encoders/text/SpacyTextEncoder/spacy_text_encoder.py
+++ b/jinahub/encoders/text/SpacyTextEncoder/spacy_text_encoder.py
@@ -6,7 +6,6 @@ from typing import Dict, Iterable, Optional
 
 import spacy
 from jina import DocumentArray, Executor, requests
-from jina_commons.batching import get_docs_batch_generator
 
 _EXCLUDE_COMPONENTS = [
     'tagger',
@@ -70,11 +69,10 @@ class SpacyTextEncoder(Executor):
             from cupy import asnumpy
         if docs:
             batch_size = parameters.get('batch_size', self.batch_size)
-            document_batches_generator = get_docs_batch_generator(
-                docs,
-                traversal_path=parameters.get('traversal_paths', self.traversal_paths),
+            document_batches_generator = docs.batch(
+                traversal_paths=parameters.get('traversal_paths', self.traversal_paths),
                 batch_size=batch_size,
-                needs_attr='text',
+                require_attr='text',
             )
             for document_batch in document_batches_generator:
                 texts = [doc.text for doc in document_batch]

--- a/jinahub/encoders/text/TFIDFTextEncoder/README.md
+++ b/jinahub/encoders/text/TFIDFTextEncoder/README.md
@@ -35,4 +35,4 @@ if __name__ == '__main__':
 - https://en.wikipedia.org/wiki/Tf-idf
 - [`sklearn.feature_extraction.text.TfidfVectorizer`](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfVectorizer.html)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/TFIDFTextEncoder/requirements.txt
+++ b/jinahub/encoders/text/TFIDFTextEncoder/requirements.txt
@@ -1,2 +1,1 @@
 scikit-learn==0.24.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/text/TFIDFTextEncoder/tfidf_text_executor.py
+++ b/jinahub/encoders/text/TFIDFTextEncoder/tfidf_text_executor.py
@@ -66,6 +66,7 @@ class TFIDFTextEncoder(Executor):
         )
 
         for document_batch in document_batches_generator:
-            iterable_of_texts = document_batch.texts
+            iterable_of_texts = [d.text for d in document_batch]
             embedding_matrix = self.tfidf_vectorizer.transform(iterable_of_texts)
-            document_batch.embeddings = embedding_matrix
+            for doc, doc_embedding in zip(document_batch, embedding_matrix):
+                doc.embedding = doc_embedding

--- a/jinahub/encoders/text/TFIDFTextEncoder/tfidf_text_executor.py
+++ b/jinahub/encoders/text/TFIDFTextEncoder/tfidf_text_executor.py
@@ -66,7 +66,6 @@ class TFIDFTextEncoder(Executor):
         )
 
         for document_batch in document_batches_generator:
-            iterable_of_texts = [d.text for d in document_batch]
+            iterable_of_texts = document_batch.texts
             embedding_matrix = self.tfidf_vectorizer.transform(iterable_of_texts)
-            for doc, doc_embedding in zip(document_batch, embedding_matrix):
-                doc.embedding = doc_embedding
+            document_batch.embeddings = embedding_matrix

--- a/jinahub/encoders/text/TextPaddleEncoder/README.md
+++ b/jinahub/encoders/text/TextPaddleEncoder/README.md
@@ -5,4 +5,4 @@
 ## Reference
 - https://www.paddlepaddle.org.cn/hublist?filter=en_category&value=SemanticModel
 
-<!-- version=v0.2 -->
+<!-- version=v0.1 -->

--- a/jinahub/encoders/text/TextPaddleEncoder/README.md
+++ b/jinahub/encoders/text/TextPaddleEncoder/README.md
@@ -5,4 +5,4 @@
 ## Reference
 - https://www.paddlepaddle.org.cn/hublist?filter=en_category&value=SemanticModel
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/TextPaddleEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/TextPaddleEncoder/gpu_requirements.txt
@@ -1,3 +1,4 @@
 paddlepaddle-gpu==2.1.0
 paddlehub==2.1.0
 sentencepiece==0.1.96
+jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.5#egg=jina-commons

--- a/jinahub/encoders/text/TextPaddleEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/TextPaddleEncoder/gpu_requirements.txt
@@ -1,4 +1,3 @@
 paddlepaddle-gpu==2.1.0
 paddlehub==2.1.0
 sentencepiece==0.1.96
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.5#egg=jina-commons

--- a/jinahub/encoders/text/TextPaddleEncoder/requirements.txt
+++ b/jinahub/encoders/text/TextPaddleEncoder/requirements.txt
@@ -1,3 +1,4 @@
 paddlepaddle==2.1.0
 paddlehub==2.1.0
 sentencepiece==0.1.96
+jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.5#egg=jina-commons

--- a/jinahub/encoders/text/TextPaddleEncoder/requirements.txt
+++ b/jinahub/encoders/text/TextPaddleEncoder/requirements.txt
@@ -1,4 +1,3 @@
 paddlepaddle==2.1.0
 paddlehub==2.1.0
 sentencepiece==0.1.96
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.5#egg=jina-commons

--- a/jinahub/encoders/text/TextPaddleEncoder/tests/integration/test_text_paddle.py
+++ b/jinahub/encoders/text/TextPaddleEncoder/tests/integration/test_text_paddle.py
@@ -4,45 +4,26 @@ import pytest
 from jina import Document, DocumentArray, Flow
 from text_paddle import TextPaddleEncoder
 
-
-@pytest.fixture(scope='function')
-def flow():
-    return Flow().add(uses=TextPaddleEncoder)
+_EMBEDDING_DIM = 1024
 
 
-@pytest.fixture(scope='function')
-def content():
-    return 'hello world'
+@pytest.mark.parametrize('request_size', [1, 10, 50, 100])
+def test_integration(request_size: int):
+    docs = DocumentArray(
+        [Document(text='just some random text here') for _ in range(50)]
+    )
+    with Flow(return_results=True).add(uses=TextPaddleEncoder) as flow:
+        resp = flow.post(
+            on='/index',
+            inputs=docs,
+            request_size=request_size,
+            return_results=True,
+        )
 
-
-@pytest.fixture(scope='function')
-def document_array(content):
-    return DocumentArray([Document(content=content)])
-
-
-def validate_callback(mock, validate_func):
-    for args, kwargs in mock.call_args_list:
-        validate_func(*args, **kwargs)
-    mock.assert_called()
-
-
-@pytest.mark.parametrize(
-    'parameters',
-    [
-        {'traverse_paths': ['r'], 'batch_size': 10},
-        {'traverse_paths': ['m'], 'batch_size': 10},
-        {'traverse_paths': ['r', 'c'], 'batch_size': 5},
-    ],
-)
-def test_text_paddle(flow, content, document_array, parameters):
-    def validate(resp):
-        for doc in resp.docs:
-            assert doc.embedding.shape == (1024,)
-            assert doc.embedding.all()
-
-    with flow as f:
-        results = f.index(inputs=document_array, return_results=True)
-    validate(results[0])
+    assert sum(len(resp_batch.docs) for resp_batch in resp) == 50
+    for r in resp:
+        for doc in r.docs:
+            assert doc.embedding.shape == (_EMBEDDING_DIM,)
 
 
 @pytest.mark.docker

--- a/jinahub/encoders/text/TextPaddleEncoder/text_paddle.py
+++ b/jinahub/encoders/text/TextPaddleEncoder/text_paddle.py
@@ -71,7 +71,7 @@ class TextPaddleEncoder(Executor):
         for batch in document_batches_generator:
             pooled_features = []
             results = self.model.get_embedding(
-                batch.texts, use_gpu=self.device == 'gpu'
+                [[x] for x in batch.texts], use_gpu=self.device == 'gpu'
             )
             for pooled_feature, _ in results:
                 pooled_features.append(pooled_feature)

--- a/jinahub/encoders/text/TextPaddleEncoder/text_paddle.py
+++ b/jinahub/encoders/text/TextPaddleEncoder/text_paddle.py
@@ -6,7 +6,6 @@ from typing import Dict, Iterable, Optional
 import numpy as np
 import paddlehub as hub
 from jina import DocumentArray, Executor, requests
-from jina_commons.batching import get_docs_batch_generator
 
 
 class TextPaddleEncoder(Executor):
@@ -61,20 +60,20 @@ class TextPaddleEncoder(Executor):
             `parameters={'traversal_paths': ['r'], 'batch_size': 10}`.
         :param kwargs: Additional key value arguments.
         """
-        if docs:
-            document_batches_generator = get_docs_batch_generator(
-                docs,
-                traversal_path=parameters.get('traversal_paths', self.traversal_paths),
-                batch_size=parameters.get('batch_size', self.batch_size),
-                needs_attr='text',
+        if docs is None:
+            return
+
+        document_batches_generator = docs.batch(
+            traversal_paths=parameters.get('traversal_paths', self.traversal_paths),
+            batch_size=parameters.get('batch_size', self.batch_size),
+            require_attr='text',
+        )
+        for batch in document_batches_generator:
+            pooled_features = []
+            results = self.model.get_embedding(
+                batch.texts, use_gpu=self.device == 'gpu'
             )
-            for batch_of_docs in document_batches_generator:
-                pooled_features = []
-                contents = [[doc.content] for doc in batch_of_docs]
-                results = self.model.get_embedding(
-                    contents, use_gpu=self.device == 'gpu'
-                )
-                for pooled_feature, _ in results:
-                    pooled_features.append(pooled_feature)
-                for doc, feature in zip(batch_of_docs, pooled_features):
-                    doc.embedding = np.asarray(feature)
+            for pooled_feature, _ in results:
+                pooled_features.append(pooled_feature)
+            for doc, feature in zip(batch, pooled_features):
+                doc.embedding = np.asarray(feature)

--- a/jinahub/encoders/text/TransformerSentenceEncoder/README.md
+++ b/jinahub/encoders/text/TransformerSentenceEncoder/README.md
@@ -6,4 +6,4 @@ library into an `Jina` executor.
 ## Reference
 - [Sentence Transformer Library](https://www.sbert.net/docs)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/encoders/text/TransformerSentenceEncoder/gpu_requirements.txt
+++ b/jinahub/encoders/text/TransformerSentenceEncoder/gpu_requirements.txt
@@ -1,3 +1,2 @@
 torch==1.9.0
 sentence-transformers==2.0.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.5#egg=jina-commons

--- a/jinahub/encoders/text/TransformerSentenceEncoder/requirements.txt
+++ b/jinahub/encoders/text/TransformerSentenceEncoder/requirements.txt
@@ -1,4 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 torch==1.9.0+cpu
 sentence-transformers==2.0.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/encoders/text/TransformerSentenceEncoder/sentence_encoder.py
+++ b/jinahub/encoders/text/TransformerSentenceEncoder/sentence_encoder.py
@@ -57,4 +57,5 @@ class TransformerSentenceEncoder(Executor):
 
             with torch.inference_mode():
                 embeddings = self.model.encode(texts)
-                batch.embeddings = embeddings
+                for doc, embedding in zip(batch, embeddings):
+                    doc.embedding = embedding

--- a/jinahub/encoders/text/TransformerSentenceEncoder/sentence_encoder.py
+++ b/jinahub/encoders/text/TransformerSentenceEncoder/sentence_encoder.py
@@ -57,5 +57,4 @@ class TransformerSentenceEncoder(Executor):
 
             with torch.inference_mode():
                 embeddings = self.model.encode(texts)
-                for doc, embedding in zip(batch, embeddings):
-                    doc.embedding = embedding
+                batch.embeddings = embeddings

--- a/jinahub/encoders/video/VideoTorchEncoder/README.md
+++ b/jinahub/encoders/video/VideoTorchEncoder/README.md
@@ -8,5 +8,5 @@ For more information, such as run executor on gpu, check out [documentation](htt
 ## Reference
 - https://pytorch.org/vision/stable/models.html#video-classification
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->
 

--- a/jinahub/encoders/video/VideoTorchEncoder/video_torch_encoder.py
+++ b/jinahub/encoders/video/VideoTorchEncoder/video_torch_encoder.py
@@ -139,4 +139,8 @@ class VideoTorchEncoder(Executor):
                     [torch.Tensor(d.blob) for d in batch_of_documents]
                 ).to(self.device)
             embedding_batch = self._get_embeddings(tensor)
-            batch_of_documents.embeddings = embedding_batch.cpu().numpy()
+            numpy_embedding_batch = embedding_batch.cpu().numpy()
+            for document, numpy_embedding in zip(
+                batch_of_documents, numpy_embedding_batch
+            ):
+                document.embedding = numpy_embedding

--- a/jinahub/encoders/video/VideoTorchEncoder/video_torch_encoder.py
+++ b/jinahub/encoders/video/VideoTorchEncoder/video_torch_encoder.py
@@ -139,8 +139,4 @@ class VideoTorchEncoder(Executor):
                     [torch.Tensor(d.blob) for d in batch_of_documents]
                 ).to(self.device)
             embedding_batch = self._get_embeddings(tensor)
-            numpy_embedding_batch = embedding_batch.cpu().numpy()
-            for document, numpy_embedding in zip(
-                batch_of_documents, numpy_embedding_batch
-            ):
-                document.embedding = numpy_embedding
+            batch_of_documents.embeddings = embedding_batch.cpu().numpy()

--- a/jinahub/encoders/video/VideoTorchEncoder/video_torch_encoder.py
+++ b/jinahub/encoders/video/VideoTorchEncoder/video_torch_encoder.py
@@ -127,7 +127,7 @@ class VideoTorchEncoder(Executor):
                 raise RuntimeError(error_msg)
 
     def _create_embeddings(self, batch_of_documents: DocumentArray):
-        with torch.no_grad():
+        with torch.inference_mode():
             if self.use_preprocessing:
                 tensors = [
                     self.transforms(torch.Tensor(d.blob).to(dtype=torch.uint8))

--- a/jinahub/rankers/CatboostRanker/README.md
+++ b/jinahub/rankers/CatboostRanker/README.md
@@ -9,4 +9,4 @@
 
 Refer to CatBoost [tutorial](https://github.com/catboost/tutorials/blob/master/ranking/ranking_tutorial.ipynb) to learn how to use CatBoost to train a ranker.
 
-<!-- version=v0.1 -->
+<!-- version=v0.1.1 -->

--- a/jinahub/rankers/CatboostRanker/requirements.txt
+++ b/jinahub/rankers/CatboostRanker/requirements.txt
@@ -1,2 +1,1 @@
 catboost==0.26
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons

--- a/jinahub/rankers/DPRReaderRanker/Dockerfile.gpu
+++ b/jinahub/rankers/DPRReaderRanker/Dockerfile.gpu
@@ -1,6 +1,5 @@
 FROM jinaai/jina:2-py37-perf
 
-RUN apt update && apt install -y git
 COPY gpu_requirements.txt gpu_requirements.txt
 RUN pip install --no-cache-dir -r gpu_requirements.txt
 

--- a/jinahub/rankers/DPRReaderRanker/README.md
+++ b/jinahub/rankers/DPRReaderRanker/README.md
@@ -89,4 +89,4 @@ f = Flow().add(
 - [DPR paper](https://arxiv.org/abs/2004.04906)
 - [Huggingface transformers DPR model documentation](https://huggingface.co/transformers/model_doc/dpr.html)
 
-<!-- version=v0.1 -->
+<!-- version=v0.2 -->

--- a/jinahub/rankers/DPRReaderRanker/gpu_requirements.txt
+++ b/jinahub/rankers/DPRReaderRanker/gpu_requirements.txt
@@ -1,3 +1,2 @@
 torch==1.9.0
 transformers==4.9.1
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.2#egg=jina-commons

--- a/jinahub/rankers/LightGBMRanker/README.md
+++ b/jinahub/rankers/LightGBMRanker/README.md
@@ -8,4 +8,4 @@
 ## Reference
 Refer to LightGBM [documentation](https://github.com/microsoft/LightGBM/tree/master/examples/lambdarank) to learn how to use LightGBM to train a ranker.
 
-<!-- version=v0.1 -->
+<!-- version=v0.1.1 -->

--- a/jinahub/rankers/LightGBMRanker/requirements.txt
+++ b/jinahub/rankers/LightGBMRanker/requirements.txt
@@ -1,2 +1,1 @@
 lightgbm==3.2.0
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons


### PR DESCRIPTION
Removes jina commons where it was used only for batching - this functionality is now superseded by `DocumentArray.batch`