### PR TITLE
fix: requirements

### DIFF
--- a/jinahub/indexers/compound/FaissPostgresIndexer/README.md
+++ b/jinahub/indexers/compound/FaissPostgresIndexer/README.md
@@ -90,5 +90,5 @@ Check [integration tests](https://github.com/jina-ai/executors/tree/main/tests/i
 
 For more advanced, full-fledged examples, check the [integration tests](https://github.com/jina-ai/executors/tree/main/tests/integration/psql_import).
 
-<!-- version=v0.2 -->
+<!-- version=v0.3 -->
 

--- a/jinahub/indexers/compound/FaissPostgresIndexer/requirements.txt
+++ b/jinahub/indexers/compound/FaissPostgresIndexer/requirements.txt
@@ -1,4 +1,4 @@
 psycopg2-binary==2.8.6
 faiss-cpu==1.6.5
-git+https://github.com/jina-ai/jina-commons
-git+https://github.com/jina-ai/executors # only required to start. DO NOT add real tests here, but in top-level integration
+jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons
+jina_executors @ git+https://github.com/jina-ai/executors


### PR DESCRIPTION
Previously FaissPSQL would not work even with `install_requirements=True` when using `jinahub://`