### PR TITLE
fix: resampling bug in audio clip

### DIFF
--- a/jinahub/encoders/audio/AudioCLIPEncoder/executor/audio_clip_encoder.py
+++ b/jinahub/encoders/audio/AudioCLIPEncoder/executor/audio_clip_encoder.py
@@ -101,7 +101,7 @@ class AudioCLIPEncoder(Executor):
                 'sample rate is not given, please provide a valid sample rate'
             )
         if orig_sr == AudioCLIPEncoder.TARGET_SAMPLE_RATE:
-            return
+            return blob, orig_sr
         return (
             lr.resample(blob, orig_sr, AudioCLIPEncoder.TARGET_SAMPLE_RATE),
             AudioCLIPEncoder.TARGET_SAMPLE_RATE,


### PR DESCRIPTION
The AudioCLIPEncoder is broken when no resampling is done.
This PR fixes this and repairs the executor.