### PR TITLE
fix: raise error in `DPRTextEncoder` when context encoder has incorrect model and update readme

### DIFF
--- a/jinahub/encoders/text/DPRTextEncoder/README.md
+++ b/jinahub/encoders/text/DPRTextEncoder/README.md
@@ -6,6 +6,11 @@ The **DPR** model was originally proposed in [Dense Passage Retrieval for Open-D
 
 This encoder supports both the DPR context and question encoders - you should specify which type you are using with the `encoder_type` parameter.
 
+If the `encoder_type` is `context`, please also specify the context encoder model by setting the `pretrained_model_name_or_path`.
+
+As an example, if `encoder_type` is `context`, you may set `pretrained_model_name_or_path` to `facebook/dpr-ctx_encoder-single-nq-base`.
+
+
 
 ## Reference
 

--- a/jinahub/encoders/text/DPRTextEncoder/README.md
+++ b/jinahub/encoders/text/DPRTextEncoder/README.md
@@ -17,4 +17,4 @@ As an example, if `encoder_type` is `context`, you may set `pretrained_model_nam
 - [DPR paper](https://arxiv.org/abs/2004.04906)
 - [Huggingface transformers DPR model documentation](https://huggingface.co/transformers/model_doc/dpr.html)
 
-<!-- version=v0.3 -->
+<!-- version=v0.4 -->

--- a/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
+++ b/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
@@ -68,6 +68,18 @@ class DPRTextEncoder(Executor):
             )
         self.encoder_type = encoder_type
 
+        if (
+            encoder_type == 'context'
+            and pretrained_model_name_or_path
+            == 'facebook/dpr-question_encoder-single-nq-base'
+        ):
+            raise ValueError(
+                'Encoder type is context but pretrained model is not set and '
+                f'default model {pretrained_model_name_or_path} is a question model.'
+                'Please ensure that pretrained_model_name_or_path is correctly set '
+                'to a dpr context encoder model.'
+            )
+
         if not base_tokenizer_model:
             base_tokenizer_model = pretrained_model_name_or_path
 

--- a/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
+++ b/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
@@ -77,7 +77,7 @@ class DPRTextEncoder(Executor):
                 'Encoder type is context but pretrained model is not set and '
                 f'default model {pretrained_model_name_or_path} is a question model. '
                 'Please ensure that pretrained_model_name_or_path is correctly set '
-                'to a dpr context encoder model.'
+                'to a dpr context encoder model. e.g. "facebook/dpr-ctx_encoder-single-nq-base" '
             )
 
         if not base_tokenizer_model:

--- a/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
+++ b/jinahub/encoders/text/DPRTextEncoder/dpr_text.py
@@ -75,7 +75,7 @@ class DPRTextEncoder(Executor):
         ):
             raise ValueError(
                 'Encoder type is context but pretrained model is not set and '
-                f'default model {pretrained_model_name_or_path} is a question model.'
+                f'default model {pretrained_model_name_or_path} is a question model. '
                 'Please ensure that pretrained_model_name_or_path is correctly set '
                 'to a dpr context encoder model.'
             )

--- a/jinahub/encoders/text/DPRTextEncoder/tests/unit/test_encoder.py
+++ b/jinahub/encoders/text/DPRTextEncoder/tests/unit/test_encoder.py
@@ -142,3 +142,11 @@ def test_quality_embeddings(basic_encoder: DPRTextEncoder):
     matches = ['B', 'A', 'D', 'C']
     for i, doc in enumerate(docs):
         assert doc.matches[1].id == matches[i]
+
+
+def test_ctx_encoder_with_incorrect_model():
+    with pytest.raises(
+        ValueError,
+        match='Please ensure that pretrained_model_name_or_path is correctly set',
+    ):
+        DPRTextEncoder(encoder_type='context')


### PR DESCRIPTION
Goals:

- [x] As per https://github.com/jina-ai/executors/issues/305, `DPRTextEncoder` is unable to start for context encoder if model path is not correctly set. The PR updates the README and raise meaningful exceptions when this happens

- [x] Bumped version (in README of Executor)

PR feedback: @jina-ai/workstream-hub 
